### PR TITLE
Trigger Github Actions on PR

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  push:
+  pull_request:
     
 jobs:
   lint:


### PR DESCRIPTION
## Description

To be sure that PR trigger Github Actions, since we will deal with PRs that come from forks, we need to trigger them on `pull_request` since we won't have a `push` when it comes from a fork.

## Related Task

[CU-74mewu]