### PR TITLE
putting primary identities at the top of the list

### DIFF
--- a/src/utils/sortIdentities.ts
+++ b/src/utils/sortIdentities.ts
@@ -33,5 +33,12 @@ export function sortIdentities(fetchedData: {
     });
   }
 
+  function sortPrimary(a: Identity, b: Identity): number {
+    return a.primary === b.primary ? 0 : a.primary ? -1 : 1;
+  }
+
+  phoneIdentities.sort(sortPrimary);
+  emailIdentities.sort(sortPrimary);
+
   return { phoneIdentities, emailIdentities };
 }

--- a/tests/unit/sortIdentities.test.ts
+++ b/tests/unit/sortIdentities.test.ts
@@ -223,4 +223,138 @@ describe("sortIdentities", () => {
     const call = sortIdentities(mockedResponse);
     expect(call).toStrictEqual(mockedSortedResponse);
   });
+
+  test("it should put the primary phone at the top of the list", () => {
+    const mockedResponse: { data: { provider: ProviderUser } } = {
+      data: {
+        provider: {
+          id: "4a5f8589-0d91-4a69-924a-6f227a69666d",
+          name: "Mocked Provider",
+          user: {
+            id: "299d268e-3e19-4486-9be7-29c539d241ac",
+            identities: [
+              {
+                id: "7f8d168a-3f65-4636-9acb-7720a212680e",
+                primary: false,
+                status: "validated",
+                type: IdentityTypes.PHONE,
+                value: "0123456789",
+              },
+              {
+                id: "hut67cc1-530b-4982-878d-33f0def6a7cf",
+                primary: true,
+                status: "validated",
+                type: IdentityTypes.PHONE,
+                value: "0677113322",
+              },
+              {
+                id: "ftardcc1-530b-4982-878d-33f0def6a7cf",
+                primary: false,
+                status: "validated",
+                type: IdentityTypes.PHONE,
+                value: "0677113300",
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const mockedSortedResponse = {
+      emailIdentities: [],
+      phoneIdentities: [
+        {
+          id: "hut67cc1-530b-4982-878d-33f0def6a7cf",
+          primary: true,
+          status: "validated",
+          type: IdentityTypes.PHONE,
+          value: "0677113322",
+        },
+        {
+          id: "7f8d168a-3f65-4636-9acb-7720a212680e",
+          primary: false,
+          status: "validated",
+          type: IdentityTypes.PHONE,
+          value: "0123456789",
+        },
+        {
+          id: "ftardcc1-530b-4982-878d-33f0def6a7cf",
+          primary: false,
+          status: "validated",
+          type: IdentityTypes.PHONE,
+          value: "0677113300",
+        },
+      ],
+    };
+
+    const call = sortIdentities(mockedResponse);
+    expect(call).toStrictEqual(mockedSortedResponse);
+  });
+
+  test("it should put the primary email at the top of the list", () => {
+    const mockedResponse: { data: { provider: ProviderUser } } = {
+      data: {
+        provider: {
+          id: "4a5f8589-0d91-4a69-924a-6f227a69666d",
+          name: "Mocked Provider",
+          user: {
+            id: "299d268e-3e19-4486-9be7-29c539d241ac",
+            identities: [
+              {
+                id: "611ed68a-3f65-4636-9acb-7720a212680e",
+                primary: false,
+                status: "validated",
+                type: IdentityTypes.EMAIL,
+                value: "test@test.test",
+              },
+              {
+                id: "0optncc1-530b-4982-878d-33f0def6a7cf",
+                primary: false,
+                status: "validated",
+                type: IdentityTypes.EMAIL,
+                value: "test2@test.test",
+              },
+              {
+                id: "ghhg5cc1-530b-4982-878d-33f0def6a7cf",
+                primary: true,
+                status: "validated",
+                type: IdentityTypes.EMAIL,
+                value: "test3@test.test",
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const mockedSortedResponse = {
+      emailIdentities: [
+        {
+          id: "ghhg5cc1-530b-4982-878d-33f0def6a7cf",
+          primary: true,
+          status: "validated",
+          type: IdentityTypes.EMAIL,
+          value: "test3@test.test",
+        },
+        {
+          id: "611ed68a-3f65-4636-9acb-7720a212680e",
+          primary: false,
+          status: "validated",
+          type: IdentityTypes.EMAIL,
+          value: "test@test.test",
+        },
+        {
+          id: "0optncc1-530b-4982-878d-33f0def6a7cf",
+          primary: false,
+          status: "validated",
+          type: IdentityTypes.EMAIL,
+          value: "test2@test.test",
+        },
+      ],
+      phoneIdentities: [],
+    };
+
+    const call = sortIdentities(mockedResponse);
+    expect(call).toStrictEqual(mockedSortedResponse);
+  });
 });


### PR DESCRIPTION
## Description
This PR aims to fix the bug of the primary identity which was not always displayed at the top of the list on `/account/logins` page
<!--- Include a summary of the changes, which issue is fixed and, relevant motivation and context -->
- I added a `sortPrimary()` function in `sortIdentities()` which will always put the primary identity at the top of the list
## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [ ] **Chore** (non-breaking change which refactors / improves the existing code base).
- [x] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Issues

<!--- Use this section if you had issues that led you to some workaround, otherwise the section can be removed -->

## How Has This Been Tested?
I added 2 tests in `@tests/unit/sortIdentities.test.ts` to check if the fix works with email and phones
<!---
Please describe the tests that you ran to verify your changes.
If needed, provide instructions, so we can reproduce (i.e. test configuration).
-->

## List of added dependencies

<!--- if appropriate, otherwise the section can be removed -->

## Screenshots

<!--- if appropriate, otherwise the section can be removed -->

## Checklist:

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
