### PR TITLE
refactoring AlertBar

### DIFF
--- a/src/components/display/fewlines/AlertBar/AlertBar.tsx
+++ b/src/components/display/fewlines/AlertBar/AlertBar.tsx
@@ -2,18 +2,24 @@ import React from "react";
 import styled from "styled-components";
 
 import { CrossIcon } from "../Icons/CrossIcon/CrossIcon";
+import { deviceBreakpoints } from "@src/design-system/theme/lightTheme";
 
 export const AlertBar: React.FC<{ text: string }> = ({ text }) => {
   const [showAlertBar, setShowAlertBar] = React.useState<boolean>(true);
   return (
     <Wrapper>
       {showAlertBar && (
-        <Alert>
-          <p>{text}</p>
-          <div className="cross" onClick={() => setShowAlertBar(false)}>
-            <CrossIcon />
-          </div>
-        </Alert>
+        <>
+          <DesktopNavigationBarSimulator />
+          <ChildrenWrapperSimulator>
+            <Alert>
+              <p>{text}</p>
+              <div className="cross" onClick={() => setShowAlertBar(false)}>
+                <CrossIcon />
+              </div>
+            </Alert>
+          </ChildrenWrapperSimulator>
+        </>
       )}
     </Wrapper>
   );
@@ -22,28 +28,53 @@ export const AlertBar: React.FC<{ text: string }> = ({ text }) => {
 export default AlertBar;
 
 const Wrapper = styled.div`
-  position: absolute;
-  top: 0;
-  left: 0;
+  position: fixed;
+  top: 2rem;
+  left: 50%;
+  margin-left: -44rem;
   width: 100%;
+  max-width: 88rem;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
+
+  @media ${deviceBreakpoints.m} {
+    max-width: 100%;
+    left: 0;
+    margin-left: 0;
+  }
+`;
+
+const DesktopNavigationBarSimulator = styled.div`
+  min-width: 24rem;
+  width: 30%;
+  height: 2rem;
+
+  @media ${deviceBreakpoints.m} {
+    display: none;
+  }
+`;
+
+const ChildrenWrapperSimulator = styled.div`
+  width: 60%;
+  margin: 0 auto;
+
+  @media ${deviceBreakpoints.m} {
+    width: 90%;
+  }
 `;
 
 const Alert = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  position: fixed;
-  width: 90%;
-  max-width: 34rem;
+  width: 100%;
+  margin: 0 auto;
   background-color: ${({ theme }) => theme.colors.black};
   color: ${({ theme }) => theme.colors.background};
   border-radius: ${({ theme }) => theme.radii[0]};
   padding: 1.6rem;
   z-index: 1;
-  top: 2rem;
   visibility: hidden;
   opacity: 0;
   animation: fadeinout 3s;

--- a/src/components/display/fewlines/AlertBar/AlertBar.tsx
+++ b/src/components/display/fewlines/AlertBar/AlertBar.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 
 import { CrossIcon } from "../Icons/CrossIcon/CrossIcon";
-import { deviceBreakpoints } from "@src/design-system/theme/lightTheme";
+import { deviceBreakpoints } from "@src/design-system/theme";
 
 export const AlertBar: React.FC<{ text: string }> = ({ text }) => {
   const [showAlertBar, setShowAlertBar] = React.useState<boolean>(true);

--- a/src/components/display/fewlines/ConfirmationBox/ConfirmationBox.tsx
+++ b/src/components/display/fewlines/ConfirmationBox/ConfirmationBox.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import { deviceBreakpoints } from "@src/design-system/theme/lightTheme";
+import { deviceBreakpoints } from "@src/design-system/theme";
 
 interface ConfirmationBoxProps {
   open: boolean;


### PR DESCRIPTION
## Description
This PR aims to reposition the `<AlertBar />` align to the `<ChildrenContainer />` regardless of the `<DesktopNavigationBar />`
<!--- Include a summary of the changes, which issue is fixed and, relevant motivation and context -->
- I displayed the `<AlertBar />` into a `position: fixed;` `<Wrapper />` that simulates the layout of the app with invisible components
- One of those components is `<DesktopNavigationBarSimulator />` that takes the same CSS properties than `<DesktopNavigationBar />`
- The second is `<ChildrenWrapperSimulator />` that simulates the `<ChildrenWrapper />`, and the `<Alert />` component is displayed within it
## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] **Chore** (non-breaking change which refactors / improves the existing code base).
- [ ] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Issues

<!--- Use this section if you had issues that led you to some workaround, otherwise the section can be removed -->

## How Has This Been Tested?
There were no need to add or modify tests
<!---
Please describe the tests that you ran to verify your changes.
If needed, provide instructions, so we can reproduce (i.e. test configuration).
-->

## List of added dependencies

<!--- if appropriate, otherwise the section can be removed -->

## Screenshots
![image](https://user-images.githubusercontent.com/33835824/97298848-565a2580-1854-11eb-92fb-197a10c1f79f.png)

<!--- if appropriate, otherwise the section can be removed -->

## Checklist:

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
