### PR TITLE
Cu 9yzyyh logins page timeline

### DIFF
--- a/src/components/display/fewlines/Icons/GhostTimelineBulletPoint/GhostTimelineBulletPoint.stories.tsx
+++ b/src/components/display/fewlines/Icons/GhostTimelineBulletPoint/GhostTimelineBulletPoint.stories.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+import { GhostTimelineBulletPoint } from "./GhostTimelineBulletPoint";
+
+export default {
+  title: "icons/Timeline Bullet Point",
+  component: GhostTimelineBulletPoint,
+};
+
+export const StandardGhostTimelineBulletPoint = (): JSX.Element => {
+  return <GhostTimelineBulletPoint />;
+};

--- a/src/components/display/fewlines/Icons/GhostTimelineBulletPoint/GhostTimelineBulletPoint.tsx
+++ b/src/components/display/fewlines/Icons/GhostTimelineBulletPoint/GhostTimelineBulletPoint.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export const GhostTimelineBulletPoint: React.FC = () => {
+  return (
+    <svg width="8" height="8" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="4" cy="4" r="3.5" fill="#fff" stroke="#F0F1F3" />
+    </svg>
+  );
+};

--- a/src/components/display/fewlines/Icons/TimelineBulletPoint/TimelineBulletPoint.stories.tsx
+++ b/src/components/display/fewlines/Icons/TimelineBulletPoint/TimelineBulletPoint.stories.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+import { TimelineBulletPoint } from "./TimelineBulletPoint";
+
+export default {
+  title: "icons/Timeline Bullet Point",
+  component: TimelineBulletPoint,
+};
+
+export const StandardTimelineBulletPoint = (): JSX.Element => {
+  return <TimelineBulletPoint />;
+};

--- a/src/components/display/fewlines/Icons/TimelineBulletPoint/TimelineBulletPoint.tsx
+++ b/src/components/display/fewlines/Icons/TimelineBulletPoint/TimelineBulletPoint.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export const TimelineBulletPoint: React.FC = () => {
+  return (
+    <svg width="8" height="8" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="4" cy="4" r="4" fill="#F0F1F3" />
+    </svg>
+  );
+};

--- a/src/components/display/fewlines/LoginsOverview/LoginsOverview.tsx
+++ b/src/components/display/fewlines/LoginsOverview/LoginsOverview.tsx
@@ -24,6 +24,7 @@ import { Separator } from "../Separator/Separator";
 import { ShadowBox } from "../ShadowBox/ShadowBox";
 import { ShowMoreButton } from "../ShowMoreButton/ShowMoreButton";
 import { Timeline } from "../Timeline/Timeline";
+import { TimelineEnd } from "../TimelineEnd/TimelineEnd";
 import type { Identity } from "@lib/@types";
 import { IdentityTypes } from "@lib/@types/Identity";
 import { SortedIdentities } from "@src/@types/SortedIdentities";
@@ -203,7 +204,7 @@ export const LoginsOverview: React.FC<LoginsOverviewProps> = ({
         </Link>
       </IdentitySection>
       <IdentitySection>
-        <Timeline />
+        <TimelineEnd />
         <h3>Social logins</h3>
         <ShadowBox>
           {socialIdentities.length === 0 ? (

--- a/src/components/display/fewlines/LoginsOverview/LoginsOverview.tsx
+++ b/src/components/display/fewlines/LoginsOverview/LoginsOverview.tsx
@@ -242,6 +242,7 @@ const Flex = styled.div`
 
 const IdentitySection = styled.div`
   margin: 0 0 ${({ theme }) => theme.spaces.s} 0;
+  position: relative;
 `;
 
 const SocialIdentityBox = styled.div`

--- a/src/components/display/fewlines/LoginsOverview/LoginsOverview.tsx
+++ b/src/components/display/fewlines/LoginsOverview/LoginsOverview.tsx
@@ -23,6 +23,7 @@ import { NeutralLink } from "../NeutralLink";
 import { Separator } from "../Separator/Separator";
 import { ShadowBox } from "../ShadowBox/ShadowBox";
 import { ShowMoreButton } from "../ShowMoreButton/ShowMoreButton";
+import { Timeline } from "../Timeline/Timeline";
 import type { Identity } from "@lib/@types";
 import { IdentityTypes } from "@lib/@types/Identity";
 import { SortedIdentities } from "@src/@types/SortedIdentities";
@@ -110,6 +111,7 @@ export const LoginsOverview: React.FC<LoginsOverviewProps> = ({
   return (
     <>
       <IdentitySection>
+        <Timeline />
         <h3>Email addresses</h3>
         <ShadowBox>
           {emailIdentities.length === 0 ? (
@@ -155,6 +157,7 @@ export const LoginsOverview: React.FC<LoginsOverviewProps> = ({
         </Link>
       </IdentitySection>
       <IdentitySection>
+        <Timeline />
         <h3>Phone numbers</h3>
         <ShadowBox>
           {phoneIdentities.length === 0 ? (
@@ -200,6 +203,7 @@ export const LoginsOverview: React.FC<LoginsOverviewProps> = ({
         </Link>
       </IdentitySection>
       <IdentitySection>
+        <Timeline />
         <h3>Social logins</h3>
         <ShadowBox>
           {socialIdentities.length === 0 ? (

--- a/src/components/display/fewlines/StoriesContainer.tsx
+++ b/src/components/display/fewlines/StoriesContainer.tsx
@@ -3,6 +3,8 @@ import styled from "styled-components";
 import { deviceBreakpoints } from "@src/design-system/theme";
 
 export const StoriesContainer = styled.div`
+  position: relative;
+  height: 100vh;
   width: 60%;
   margin: 0 auto;
 

--- a/src/components/display/fewlines/Timeline/Timeline.stories.tsx
+++ b/src/components/display/fewlines/Timeline/Timeline.stories.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+import { StoriesContainer } from "../StoriesContainer";
+import { Timeline } from "./Timeline";
+
+export default {
+  title: "components/Timeline",
+  component: Timeline,
+};
+
+export const StandardTimeLine = (): JSX.Element => {
+  return (
+    <StoriesContainer>
+      <Timeline />
+    </StoriesContainer>
+  );
+};

--- a/src/components/display/fewlines/Timeline/Timeline.tsx
+++ b/src/components/display/fewlines/Timeline/Timeline.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 
 import { TimelineBulletPoint } from "../Icons/TimelineBulletPoint/TimelineBulletPoint";
+import { deviceBreakpoints } from "@src/design-system/theme/decatTheme";
 
 export const Timeline: React.FC = () => {
   return (
@@ -18,11 +19,15 @@ export const Timeline: React.FC = () => {
 
 const Flex = styled.div`
   position: absolute;
-  left: -1.5rem;
-  display: flex;
+  left: -1.7rem;
+  display: none;
   flex-direction: column;
   height: 100%;
   width: 0.8rem;
+
+  @media ${deviceBreakpoints.m} {
+    display: flex;
+  }
 `;
 
 const BulletPointContainer = styled.div`

--- a/src/components/display/fewlines/Timeline/Timeline.tsx
+++ b/src/components/display/fewlines/Timeline/Timeline.tsx
@@ -5,29 +5,38 @@ import { TimelineBulletPoint } from "../Icons/TimelineBulletPoint/TimelineBullet
 
 export const Timeline: React.FC = () => {
   return (
-    <>
+    <Flex>
       <BulletPointContainer>
         <TimelineBulletPoint />
       </BulletPointContainer>
-      <TimelineContainer>
+      <LineContainer>
         <Line />
-      </TimelineContainer>
-    </>
+      </LineContainer>
+    </Flex>
   );
 };
 
-const BulletPointContainer = styled.div`
-  display: inline-block;
+const Flex = styled.div`
+  position: absolute;
+  left: -1.5rem;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 0.8rem;
 `;
 
-const TimelineContainer = styled.div`
-  display: block;
+const BulletPointContainer = styled.div`
   width: 0.8rem;
-  height: 100%;
+  margin: 0 0 ${({ theme }) => theme.spaces.xxs} 0;
+`;
+
+const LineContainer = styled.div`
+  width: 0.8rem;
   margin: 0 0 0 0.4rem;
+  height: 100%;
 `;
 
 const Line = styled.div`
-  height: calc(100% + ${({ theme }) => theme.spaces.s});
+  height: calc(95% + ${({ theme }) => theme.spaces.s});
   border-left: 1px solid ${({ theme }) => theme.colors.separator};
 `;

--- a/src/components/display/fewlines/Timeline/Timeline.tsx
+++ b/src/components/display/fewlines/Timeline/Timeline.tsx
@@ -19,7 +19,7 @@ export const Timeline: React.FC = () => {
 
 const Flex = styled.div`
   position: absolute;
-  left: -1.7rem;
+  left: -1.5rem;
   display: none;
   flex-direction: column;
   height: 100%;

--- a/src/components/display/fewlines/Timeline/Timeline.tsx
+++ b/src/components/display/fewlines/Timeline/Timeline.tsx
@@ -1,14 +1,33 @@
 import React from "react";
 import styled from "styled-components";
 
+import { TimelineBulletPoint } from "../Icons/TimelineBulletPoint/TimelineBulletPoint";
+
 export const Timeline: React.FC = () => {
-  return <Content />;
+  return (
+    <>
+      <BulletPointContainer>
+        <TimelineBulletPoint />
+      </BulletPointContainer>
+      <TimelineContainer>
+        <Line />
+      </TimelineContainer>
+    </>
+  );
 };
 
-const Content = styled.div`
-  position: absolute;
-  top: 0;
-  left: 0;
+const BulletPointContainer = styled.div`
+  display: inline-block;
+`;
+
+const TimelineContainer = styled.div`
+  display: block;
+  width: 0.8rem;
+  height: 100%;
+  margin: 0 0 0 0.4rem;
+`;
+
+const Line = styled.div`
   height: calc(100% + ${({ theme }) => theme.spaces.s});
   border-left: 1px solid ${({ theme }) => theme.colors.separator};
 `;

--- a/src/components/display/fewlines/Timeline/Timeline.tsx
+++ b/src/components/display/fewlines/Timeline/Timeline.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import styled from "styled-components";
+
+export const Timeline: React.FC = () => {
+  return <Content />;
+};
+
+const Content = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: calc(100% + ${({ theme }) => theme.spaces.s});
+  border-left: 1px solid ${({ theme }) => theme.colors.separator};
+`;

--- a/src/components/display/fewlines/TimelineEnd/TimelineEnd.stories.tsx
+++ b/src/components/display/fewlines/TimelineEnd/TimelineEnd.stories.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+import { StoriesContainer } from "../StoriesContainer";
+import { TimelineEnd } from "./TimelineEnd";
+
+export default {
+  title: "components/TimelineEnd",
+  component: TimelineEnd,
+};
+
+export const StandardTimeLineEnd = (): JSX.Element => {
+  return (
+    <StoriesContainer>
+      <TimelineEnd />
+    </StoriesContainer>
+  );
+};

--- a/src/components/display/fewlines/TimelineEnd/TimelineEnd.tsx
+++ b/src/components/display/fewlines/TimelineEnd/TimelineEnd.tsx
@@ -13,9 +13,9 @@ export const TimelineEnd: React.FC = () => {
       <LineContainer>
         <Line />
       </LineContainer>
-      <BulletPointContainer>
+      <GhostBulletPointContainer>
         <GhostTimelineBulletPoint />
-      </BulletPointContainer>
+      </GhostBulletPointContainer>
     </Flex>
   );
 };
@@ -32,6 +32,11 @@ const Flex = styled.div`
 const BulletPointContainer = styled.div`
   width: 0.8rem;
   margin: 0 0 ${({ theme }) => theme.spaces.xxs} 0;
+`;
+
+const GhostBulletPointContainer = styled.div`
+  width: 0.8rem;
+  margin: 0 0 -1rem 0;
 `;
 
 const LineContainer = styled.div`

--- a/src/components/display/fewlines/TimelineEnd/TimelineEnd.tsx
+++ b/src/components/display/fewlines/TimelineEnd/TimelineEnd.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 import { GhostTimelineBulletPoint } from "../Icons/GhostTimelineBulletPoint/GhostTimelineBulletPoint";
 import { TimelineBulletPoint } from "../Icons/TimelineBulletPoint/TimelineBulletPoint";
+import { deviceBreakpoints } from "@src/design-system/theme/decatTheme";
 
 export const TimelineEnd: React.FC = () => {
   return (
@@ -22,11 +23,15 @@ export const TimelineEnd: React.FC = () => {
 
 const Flex = styled.div`
   position: absolute;
-  left: -1.5rem;
-  display: flex;
+  left: -1.7rem;
+  display: none;
   flex-direction: column;
   height: 100%;
   width: 0.8rem;
+
+  @media ${deviceBreakpoints.m} {
+    display: flex;
+  }
 `;
 
 const BulletPointContainer = styled.div`

--- a/src/components/display/fewlines/TimelineEnd/TimelineEnd.tsx
+++ b/src/components/display/fewlines/TimelineEnd/TimelineEnd.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import styled from "styled-components";
+
+import { GhostTimelineBulletPoint } from "../Icons/GhostTimelineBulletPoint/GhostTimelineBulletPoint";
+import { TimelineBulletPoint } from "../Icons/TimelineBulletPoint/TimelineBulletPoint";
+
+export const TimelineEnd: React.FC = () => {
+  return (
+    <Flex>
+      <BulletPointContainer>
+        <TimelineBulletPoint />
+      </BulletPointContainer>
+      <LineContainer>
+        <Line />
+      </LineContainer>
+      <BulletPointContainer>
+        <GhostTimelineBulletPoint />
+      </BulletPointContainer>
+    </Flex>
+  );
+};
+
+const Flex = styled.div`
+  position: absolute;
+  left: -1.5rem;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 0.8rem;
+`;
+
+const BulletPointContainer = styled.div`
+  width: 0.8rem;
+  margin: 0 0 ${({ theme }) => theme.spaces.xxs} 0;
+`;
+
+const LineContainer = styled.div`
+  width: 0.8rem;
+  margin: 0 0 0 0.4rem;
+  height: 100%;
+`;
+
+const Line = styled.div`
+  height: 100%;
+  border-left: 1px solid ${({ theme }) => theme.colors.separator};
+`;

--- a/src/components/display/fewlines/TimelineEnd/TimelineEnd.tsx
+++ b/src/components/display/fewlines/TimelineEnd/TimelineEnd.tsx
@@ -23,7 +23,7 @@ export const TimelineEnd: React.FC = () => {
 
 const Flex = styled.div`
   position: absolute;
-  left: -1.7rem;
+  left: -1.5rem;
   display: none;
   flex-direction: column;
   height: 100%;


### PR DESCRIPTION
## Description
This PR aims to implement the timeline in `<LoginsOverview />` only on the mobile view in accordance with our wireframe
<!--- Include a summary of the changes, which issue is fixed and, relevant motivation and context -->
- I added 2 icons `<TimelineBulletPoint />` and `<GhostTimelineBulletPoint />` and their stories
- I created 2 components `<TimeLine />` and `<TimelineEnd />` with specific CSS rules, and their stories
- I implemented these 2 components in `<LoginsOverview />`
- In `<LoginsOverview />`, I turned `<IdentityOverview />` into `position: relative;` so that the timelines will fit perfectly whatever its size
## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [ ] **Chore** (non-breaking change which refactors / improves the existing code base).
- [ ] **Bug fix** (non-breaking change which fixes an issue).
- [x] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Issues

<!--- Use this section if you had issues that led you to some workaround, otherwise the section can be removed -->

## How Has This Been Tested?
There were no need to add or modify tests
<!---
Please describe the tests that you ran to verify your changes.
If needed, provide instructions, so we can reproduce (i.e. test configuration).
-->

## List of added dependencies

<!--- if appropriate, otherwise the section can be removed -->

## Screenshots
![image](https://user-images.githubusercontent.com/33835824/98554669-46553380-22a1-11eb-8b1e-c9299d06fea1.png)

<!--- if appropriate, otherwise the section can be removed -->

## Checklist:

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
