### PR TITLE
Cu a0w4y8 fix mobile display

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -31,6 +31,8 @@ export const Main = styled.main`
 
   @media ${deviceBreakpoints.m} {
     height: auto;
+    max-height: calc(100vh - 7.2rem);
+    overflow: scroll;
   }
 `;
 

--- a/src/components/display/fewlines/Home/Home.tsx
+++ b/src/components/display/fewlines/Home/Home.tsx
@@ -82,6 +82,6 @@ export const BackLink = styled.p`
   cursor: pointer;
 `;
 
-const AccessButton = styled(Button)`
+export const AccessButton = styled(Button)`
   margin: 0;
 `;

--- a/src/components/display/fewlines/Home/Home.tsx
+++ b/src/components/display/fewlines/Home/Home.tsx
@@ -24,9 +24,9 @@ export const Home: React.FC<HomeProps> = ({ authorizeURL, providerName }) => {
               </DescriptionText>
               <Link href={authorizeURL}>
                 <a>
-                  <Button variant={ButtonVariant.PRIMARY}>
+                  <AccessButton variant={ButtonVariant.PRIMARY}>
                     Access my account
-                  </Button>
+                  </AccessButton>
                 </a>
               </Link>
             </Flex>
@@ -66,12 +66,12 @@ const Flex = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding: ${({ theme }) => theme.spaces.xs} ${({ theme }) => theme.spaces.s};
+  padding: ${({ theme }) => theme.spaces.s};
 `;
 
 const DescriptionText = styled.p`
   text-align: center;
-  margin: ${({ theme }) => theme.spaces.xs} 0;
+  margin: 0 0 ${({ theme }) => theme.spaces.xs} 0;
   font-weight: ${({ theme }) => theme.fontWeights.semibold};
 `;
 
@@ -80,4 +80,8 @@ export const BackLink = styled.p`
   margin: ${({ theme }) => theme.spaces.xs} 0;
   color: ${({ theme }) => theme.colors.primary};
   cursor: pointer;
+`;
+
+const AccessButton = styled(Button)`
+  margin: 0;
 `;

--- a/src/components/display/fewlines/Icons/HomeDesktopBackground/HomeDesktopBackground.tsx
+++ b/src/components/display/fewlines/Icons/HomeDesktopBackground/HomeDesktopBackground.tsx
@@ -211,7 +211,7 @@ export const HomeDesktopBackground: React.FC = () => {
 };
 
 const Wrapper = styled.div`
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   width: 100%;

--- a/tests/pages/HomePage.test.tsx
+++ b/tests/pages/HomePage.test.tsx
@@ -1,10 +1,8 @@
 import { mount } from "enzyme";
 import React from "react";
 
-import {
-  Button,
-  ButtonVariant,
-} from "@src/components/display/fewlines/Button/Button";
+import { ButtonVariant } from "@src/components/display/fewlines/Button/Button";
+import { AccessButton } from "@src/components/display/fewlines/Home/Home";
 import HomePage from "@src/pages";
 import { AccountApp } from "@src/pages/_app";
 
@@ -16,11 +14,11 @@ describe("HomePage", () => {
       </AccountApp>,
     );
 
-    const accountButton = component
-      .find(Button)
+    const accountAccessButton = component
+      .find(AccessButton)
       .find({ variant: ButtonVariant.PRIMARY });
 
-    expect(accountButton).toHaveLength(1);
-    expect(accountButton.text()).toEqual("Access my account");
+    expect(accountAccessButton).toHaveLength(1);
+    expect(accountAccessButton.text()).toEqual("Access my account");
   });
 });


### PR DESCRIPTION
## Description
This PR aims to fix the `<LoginsOverview />` component in which a part was hidden by the `<MobileNavigationBar />`, I took the opportunity to add other small fixes
<!--- Include a summary of the changes, which issue is fixed and, relevant motivation and context -->
- I added `max-height: calc(100vh - 7.2rem);` (7.2 is the `<MobileNavigationBar />`'s height) and `overflow: scroll;` to `<Layout />` so that it's size will fit perfectly the screen size regardless the navbar
- I removed the `margin-bottom` property of the `<Button />` in `<Home />` component, so that only itself would be clickable (not its `margin-bottom`)
- I gave `position: fixed;` property to `<HomeDesktopBackground />` to prevent the page to scroll in case of overflow and to give it a real background image effect

## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [ ] **Chore** (non-breaking change which refactors / improves the existing code base).
- [x] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Issues

<!--- Use this section if you had issues that led you to some workaround, otherwise the section can be removed -->

## How Has This Been Tested?
I modified tests imports only
<!---
Please describe the tests that you ran to verify your changes.
If needed, provide instructions, so we can reproduce (i.e. test configuration).
-->

## List of added dependencies

<!--- if appropriate, otherwise the section can be removed -->

## Screenshots
![image](https://user-images.githubusercontent.com/33835824/98571816-35162200-22b5-11eb-827d-311376b6e400.png)
![image](https://user-images.githubusercontent.com/33835824/98571674-14e66300-22b5-11eb-9328-b864ec13e632.png)

<!--- if appropriate, otherwise the section can be removed -->

## Checklist:

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
