### PR TITLE
Cu a101jr replacing router push by links

### DIFF
--- a/src/components/display/fewlines/AddIdentityForm/AddIdentityForm.tsx
+++ b/src/components/display/fewlines/AddIdentityForm/AddIdentityForm.tsx
@@ -1,9 +1,10 @@
-import { useRouter } from "next/router";
+import Link from "next/link";
 import React from "react";
 
 import { Button, ButtonVariant } from "../Button/Button";
 import { Form } from "../Form/Form";
 import { Input } from "../Input/Input";
+import { NeutralLink } from "../NeutralLink";
 import { IdentityTypes } from "@lib/@types";
 import { InMemoryTemporaryIdentity } from "@src/@types/InMemoryTemporaryIdentity";
 
@@ -21,8 +22,6 @@ export const AddIdentityForm: React.FC<AddIdentityFormProps> = ({
     type,
     expiresAt: Date.now(),
   });
-
-  const router = useRouter();
 
   return (
     <>
@@ -55,12 +54,11 @@ export const AddIdentityForm: React.FC<AddIdentityFormProps> = ({
           type="submit"
         >{`Add ${type.toLowerCase()}`}</Button>
       </Form>
-      <Button
-        variant={ButtonVariant.SECONDARY}
-        onClick={() => router.push("/account/logins/")}
-      >
-        Cancel
-      </Button>
+      <Link href="/account/logins">
+        <NeutralLink>
+          <Button variant={ButtonVariant.SECONDARY}>Cancel</Button>
+        </NeutralLink>
+      </Link>
     </>
   );
 };

--- a/src/components/display/fewlines/AddIdentityForm/AddIdentityForm.tsx
+++ b/src/components/display/fewlines/AddIdentityForm/AddIdentityForm.tsx
@@ -54,7 +54,7 @@ export const AddIdentityForm: React.FC<AddIdentityFormProps> = ({
           type="submit"
         >{`Add ${type.toLowerCase()}`}</Button>
       </Form>
-      <Link href="/account/logins">
+      <Link href="/account/logins" passHref>
         <NeutralLink>
           <Button variant={ButtonVariant.SECONDARY}>Cancel</Button>
         </NeutralLink>

--- a/src/components/display/fewlines/DesktopNavigationBar/DesktopNavigationBar.tsx
+++ b/src/components/display/fewlines/DesktopNavigationBar/DesktopNavigationBar.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from "next/router";
+import Link from "next/link";
 import React from "react";
 import styled from "styled-components";
 
@@ -12,33 +12,37 @@ import { NeutralLink } from "../NeutralLink";
 import { Separator } from "../Separator/Separator";
 
 export const DesktopNavigationBar: React.FC = () => {
-  const router = useRouter();
-
   return (
     <Bar>
       <Header />
-      <ListItem onClick={() => router.push("/account")}>
-        <HomeIcon />
-        <ListLabel>Home</ListLabel>
-      </ListItem>
-      <ListItem onClick={() => router.push("/account/logins")}>
-        <KeyIcon />
-        <ListLabel>Logins</ListLabel>
-      </ListItem>
-      <ListItem>
-        <LockIcon />
-        <ListLabel onClick={() => router.push("/account/security")}>
-          Security
-        </ListLabel>
-      </ListItem>
+      <Link href="/account" passHref>
+        <ListItem>
+          <HomeIcon />
+          <ListLabel>Home</ListLabel>
+        </ListItem>
+      </Link>
+      <Link href="/account/logins" passHref>
+        <ListItem>
+          <KeyIcon />
+          <ListLabel>Logins</ListLabel>
+        </ListItem>
+      </Link>
+      <Link href="/account/security" passHref>
+        <ListItem>
+          <LockIcon />
+          <ListLabel>Security</ListLabel>
+        </ListItem>
+      </Link>
       <Separator />
-      <SwitchLanguageItem onClick={() => router.push("/account/locale")}>
-        <SwitchLanguageLabel>
-          <BlackWorldIcon />
-          <ListLabel>English</ListLabel>
-        </SwitchLanguageLabel>
-        <BlackSwitchIcon />
-      </SwitchLanguageItem>
+      <Link href="/account/locale" passHref>
+        <SwitchLanguageItem>
+          <SwitchLanguageLabel>
+            <BlackWorldIcon />
+            <ListLabel>English</ListLabel>
+          </SwitchLanguageLabel>
+          <BlackSwitchIcon />
+        </SwitchLanguageItem>
+      </Link>
     </Bar>
   );
 };
@@ -52,18 +56,16 @@ const ListItem = styled(NeutralLink)`
   align-items: center;
   padding: ${({ theme }) => theme.spaces.xs} 0 ${({ theme }) => theme.spaces.xs}
     ${({ theme }) => theme.spaces.xs};
-  cursor: pointer;
 `;
 
 const ListLabel = styled.p`
   margin: 0 0 0 ${({ theme }) => theme.spaces.xs};
 `;
 
-const SwitchLanguageItem = styled.div`
+const SwitchLanguageItem = styled(NeutralLink)`
   display: flex;
   justify-content: space-between;
   padding: ${({ theme }) => theme.spaces.xs};
-  cursor: pointer;
 `;
 
 const SwitchLanguageLabel = styled.div`

--- a/src/components/display/fewlines/ErrorFallback/ErrorFallback.tsx
+++ b/src/components/display/fewlines/ErrorFallback/ErrorFallback.tsx
@@ -15,7 +15,7 @@ export const ErrorFallback: React.FC<ErrorFallbackProps> = ({ statusCode }) => {
           <p>
             It may have expired, or there could be a typo. Maybe you can find
             what you need on our{" "}
-            <Link href="/">
+            <Link href="/" passHref>
               <a>homepage</a>
             </Link>
             .

--- a/src/components/display/fewlines/Header/Header.tsx
+++ b/src/components/display/fewlines/Header/Header.tsx
@@ -9,7 +9,7 @@ export const Header: React.FC = () => {
 
   return (
     <Flex>
-      <Link href="/account">
+      <Link href="/account" passHref>
         <a>
           <img width="90" src={theme.logo} aria-label="Logo" />
         </a>

--- a/src/components/display/fewlines/Home/Home.tsx
+++ b/src/components/display/fewlines/Home/Home.tsx
@@ -22,7 +22,7 @@ export const Home: React.FC<HomeProps> = ({ authorizeURL, providerName }) => {
               <DescriptionText>
                 You are about to access your account from {providerName}
               </DescriptionText>
-              <Link href={authorizeURL}>
+              <Link href={authorizeURL} passHref>
                 <a>
                   <Button variant={ButtonVariant.PRIMARY}>
                     Access my account

--- a/src/components/display/fewlines/IdentityOverview/IdentityOverview.tsx
+++ b/src/components/display/fewlines/IdentityOverview/IdentityOverview.tsx
@@ -42,7 +42,7 @@ export const IdentityOverview: React.FC<IdentityOverviewProps> = ({
         )}
       </Box>
       {status === "unvalidated" && (
-        <Link href={`/account/logins/${type}/validation`}>
+        <Link href={`/account/logins/${type}/validation`} passHref>
           <a>
             <Button variant={ButtonVariant.PRIMARY}>
               proceed to validation
@@ -51,7 +51,7 @@ export const IdentityOverview: React.FC<IdentityOverviewProps> = ({
         </Link>
       )}
       {/* {status === "validated" && (
-        <Link href={`/account/logins/${type}/${id}/update`}>
+        <Link href={`/account/logins/${type}/${id}/update`} passHref>
           <a>
             <Button variant={ButtonVariant.PRIMARY}>
               Update this{" "}

--- a/src/components/display/fewlines/LoginsOverview/LoginsOverview.tsx
+++ b/src/components/display/fewlines/LoginsOverview/LoginsOverview.tsx
@@ -123,6 +123,7 @@ export const LoginsOverview: React.FC<LoginsOverviewProps> = ({
                     as={`/account/logins/${email.type.toLowerCase()}/${
                       email.id
                     }`}
+                    passHref
                   >
                     <BoxedLink primary={email.primary} status={email.status}>
                       <p>{email.value}</p>
@@ -146,7 +147,7 @@ export const LoginsOverview: React.FC<LoginsOverviewProps> = ({
             />
           </Flex>
         )}
-        <Link href="/account/logins/email/new">
+        <Link href="/account/logins/email/new" passHref>
           <a>
             <Button variant={ButtonVariant.SECONDARY}>
               + Add new email address
@@ -168,6 +169,7 @@ export const LoginsOverview: React.FC<LoginsOverviewProps> = ({
                     as={`/account/logins/${phone.type.toLowerCase()}/${
                       phone.id
                     }`}
+                    passHref
                   >
                     <BoxedLink primary={phone.primary} status={phone.status}>
                       <p>{phone.value}</p>
@@ -191,7 +193,7 @@ export const LoginsOverview: React.FC<LoginsOverviewProps> = ({
             />
           </Flex>
         )}
-        <Link href="/account/logins/phone/new">
+        <Link href="/account/logins/phone/new" passHref>
           <a>
             <Button variant={ButtonVariant.SECONDARY}>
               + Add new phone number

--- a/src/components/display/fewlines/MobileNavigationBar/MobileNavigationBar.tsx
+++ b/src/components/display/fewlines/MobileNavigationBar/MobileNavigationBar.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { useRouter } from "next/router";
 import React from "react";
 import styled from "styled-components";
@@ -30,56 +31,49 @@ export const MobileNavigationBar: React.FC = () => {
       <Container>
         {isOpen && (
           <MenuList>
-            <ListItem
-              onClick={() =>
-                router.push("/account").then(() => setIsOpen(false))
-              }
-            >
-              <ListItemLabel>
-                <HomeIcon />
-                <Value>Home</Value>
-              </ListItemLabel>
-              <RightChevron />
-            </ListItem>
-            <ListItem
-              onClick={() =>
-                router.push("/account/logins").then(() => setIsOpen(false))
-              }
-            >
-              <ListItemLabel>
-                <KeyIcon />
-                <Value>Logins</Value>
-              </ListItemLabel>
-              <RightChevron />
-            </ListItem>
-            <ListItem
-              onClick={() =>
-                router.push("/account/security").then(() => setIsOpen(false))
-              }
-            >
-              <ListItemLabel>
-                <LockIcon />
-                <Value>Security</Value>
-              </ListItemLabel>
-              <RightChevron />
-            </ListItem>
+            <Link href="/account" passHref>
+              <ListItem onClick={() => setIsOpen(false)}>
+                <ListItemLabel>
+                  <HomeIcon />
+                  <Value>Home</Value>
+                </ListItemLabel>
+                <RightChevron />
+              </ListItem>
+            </Link>
+            <Link href="/account/logins" passHref>
+              <ListItem onClick={() => setIsOpen(false)}>
+                <ListItemLabel>
+                  <KeyIcon />
+                  <Value>Logins</Value>
+                </ListItemLabel>
+                <RightChevron />
+              </ListItem>
+            </Link>
+            <Link href="/account/security" passHref>
+              <ListItem onClick={() => setIsOpen(false)}>
+                <ListItemLabel>
+                  <LockIcon />
+                  <Value>Security</Value>
+                </ListItemLabel>
+                <RightChevron />
+              </ListItem>
+            </Link>
           </MenuList>
         )}
         <Bar>
           {isOpen ? (
-            <MenuItem
-              color="primary"
-              onClick={() =>
-                router.push("/account/locale").then(() => setIsOpen(false))
-              }
-            >
-              <Content>
-                <LanguagesOptions>
-                  <WhiteWorldIcon />
-                  <div>English</div>
-                </LanguagesOptions>
-                <WhiteSwitchIcon />
-              </Content>
+            <MenuItem color="primary" onClick={() => setIsOpen(false)}>
+              <Link href="/account/locale" passHref>
+                <SpecialLink>
+                  <Content>
+                    <LanguagesOptions>
+                      <WhiteWorldIcon />
+                      <div>English</div>
+                    </LanguagesOptions>
+                    <WhiteSwitchIcon />
+                  </Content>
+                </SpecialLink>
+              </Link>
             </MenuItem>
           ) : (
             <MenuItem onClick={() => router.back()}>
@@ -186,4 +180,8 @@ const ListItemLabel = styled.div`
 
 const Value = styled.p`
   margin: 0 0 0 ${({ theme }) => theme.spaces.xs};
+`;
+
+const SpecialLink = styled(NeutralLink)`
+  color: inherit;
 `;

--- a/src/components/display/fewlines/SectionListItem/SectionListItem.tsx
+++ b/src/components/display/fewlines/SectionListItem/SectionListItem.tsx
@@ -19,7 +19,7 @@ export const SectionListItem: React.FC<SectionListItemProps> = ({
 
   return (
     <ShadowBox>
-      <Link href={`/account/${sectionName.toLocaleLowerCase()}`}>
+      <Link href={`/account/${sectionName.toLocaleLowerCase()}`} passHref>
         <Flex>
           {icon}
           <TextBox>
@@ -38,7 +38,6 @@ const Flex = styled(NeutralLink)`
   justify-content: space-between;
   align-items: center;
   padding: ${({ theme }) => theme.spaces.xs};
-  cursor: pointer;
 `;
 
 export const TextBox = styled.div`

--- a/src/components/display/fewlines/Security/Security.tsx
+++ b/src/components/display/fewlines/Security/Security.tsx
@@ -15,7 +15,7 @@ export const Security: React.FC<SecurityProps> = ({ isPasswordSet }) => {
     <>
       <h3>Password</h3>
       <ShadowBox>
-        <Link href="/account/security/update">
+        <Link href="/account/security/update" passHref>
           <Flex>
             <TextBox>{isPasswordSet ? "Update" : "Set"} your password</TextBox>
             <RightChevron />

--- a/src/components/display/fewlines/UpdateIdentityForm/UpdateIdentityForm.tsx
+++ b/src/components/display/fewlines/UpdateIdentityForm/UpdateIdentityForm.tsx
@@ -1,10 +1,11 @@
-import { useRouter } from "next/router";
+import Link from "next/link";
 import React from "react";
 import styled from "styled-components";
 
 import { Button, ButtonVariant } from "../Button/Button";
 import { Form } from "../Form/Form";
 import { Input } from "../Input/Input";
+import { NeutralLink } from "../NeutralLink";
 import { Identity, IdentityTypes } from "@lib/@types";
 import { Box } from "@src/components/display/fewlines/Box/Box";
 
@@ -13,7 +14,6 @@ export const UpdateIdentityForm: React.FC<{
   currentIdentity: Identity;
 }> = ({ currentIdentity, updateIdentity }) => {
   const [identity, setIdentity] = React.useState("");
-  const router = useRouter();
   const { value } = currentIdentity;
 
   return (
@@ -44,12 +44,11 @@ export const UpdateIdentityForm: React.FC<{
           Update {currentIdentity.type}
         </Button>
       </Form>
-      <Button
-        variant={ButtonVariant.SECONDARY}
-        onClick={() => router.push("/account/logins/")}
-      >
-        Cancel
-      </Button>
+      <Link href="/account/logins">
+        <NeutralLink>
+          <Button variant={ButtonVariant.SECONDARY}>Cancel</Button>
+        </NeutralLink>
+      </Link>
     </>
   );
 };

--- a/src/components/display/fewlines/UpdateIdentityForm/UpdateIdentityForm.tsx
+++ b/src/components/display/fewlines/UpdateIdentityForm/UpdateIdentityForm.tsx
@@ -44,7 +44,7 @@ export const UpdateIdentityForm: React.FC<{
           Update {currentIdentity.type}
         </Button>
       </Form>
-      <Link href="/account/logins">
+      <Link href="/account/logins" passHref>
         <NeutralLink>
           <Button variant={ButtonVariant.SECONDARY}>Cancel</Button>
         </NeutralLink>

--- a/src/components/display/fewlines/ValidateIdentityForm/ValidateIdentityForm.tsx
+++ b/src/components/display/fewlines/ValidateIdentityForm/ValidateIdentityForm.tsx
@@ -45,7 +45,7 @@ export const ValidateIdentityForm: React.FC<{
           type="submit"
         >{`Confirm ${type.toLowerCase()}`}</Button>
       </Form>
-      <Link href="/account/logins">
+      <Link href="/account/logins" passHref>
         <NeutralLink>
           <Button variant={ButtonVariant.SECONDARY}>Discard all changes</Button>
         </NeutralLink>

--- a/src/components/display/fewlines/ValidateIdentityForm/ValidateIdentityForm.tsx
+++ b/src/components/display/fewlines/ValidateIdentityForm/ValidateIdentityForm.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from "next/router";
+import Link from "next/link";
 import React from "react";
 import styled from "styled-components";
 
@@ -6,6 +6,7 @@ import { Box } from "../Box/Box";
 import { Button, ButtonVariant } from "../Button/Button";
 import { Form } from "../Form/Form";
 import { Input } from "../Input/Input";
+import { NeutralLink } from "../NeutralLink";
 import { IdentityTypes } from "@lib/@types/Identity";
 import { displayAlertBar } from "@src/utils/displayAlertBar";
 
@@ -14,8 +15,6 @@ export const ValidateIdentityForm: React.FC<{
   validateIdentity: (validationCode: string) => Promise<void>;
 }> = ({ type, validateIdentity }) => {
   const [validationCode, setValidationCode] = React.useState("");
-
-  const router = useRouter();
 
   return (
     <>
@@ -46,12 +45,12 @@ export const ValidateIdentityForm: React.FC<{
           type="submit"
         >{`Confirm ${type.toLowerCase()}`}</Button>
       </Form>
-      <Button
-        variant={ButtonVariant.SECONDARY}
-        onClick={() => router.push("/account/logins/")}
-      >
-        Discard all changes
-      </Button>
+      <Link href="/account/logins">
+        <NeutralLink>
+          <Button variant={ButtonVariant.SECONDARY}>Discard all changes</Button>
+        </NeutralLink>
+      </Link>
+
       <DidntReceiveCode>Didn&apos;t receive code?</DidntReceiveCode>
       <Button variant={ButtonVariant.SECONDARY}>
         Resend confirmation code

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,7 +42,7 @@ const config: Config = {
 
 function handleEnvVars(): void {
   config.connectDomain = process.env.CONNECT_ACCOUNT_DOMAIN || "";
-  config.connectTheme = process.env.CONNECT_ACCOUNT_THEME || "decathlon";
+  config.connectTheme = process.env.CONNECT_ACCOUNT_THEME || "fewlines";
   config.connectManagementUrl = process.env.CONNECT_MANAGEMENT_URL || "";
   config.connectMongoUrl = process.env.MONGO_URL || "";
   config.connectMongoDbName = process.env.MONGO_DB_NAME || "";

--- a/src/design-system/theme/index.ts
+++ b/src/design-system/theme/index.ts
@@ -14,12 +14,12 @@ import { config } from "@src/config";
 let theme: DefaultTheme;
 let deviceBreakpoints: DeviceBreakpoints;
 
-if (config.connectTheme === "fewlines") {
-  deviceBreakpoints = fewlinesDeviceBreakpoints;
-  theme = lightTheme;
-} else {
+if (config.connectTheme === "decathlon") {
   theme = decatTheme;
   deviceBreakpoints = decatDeviceBreakpoints;
+} else {
+  theme = lightTheme;
+  deviceBreakpoints = fewlinesDeviceBreakpoints;
 }
 
 export { theme, deviceBreakpoints };


### PR DESCRIPTION
## Description

The point of this PR was to replace the usage of router.push() to mimic links _(anchors)_ behaviour by actual anchor tags, more precisely Next's ones. 
I also added `passHref` props to already existing Next's Link to ensure accessibility _(tab navigation)_, plus some minors style changes due to new tags.


## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] **Chore** (non-breaking change which refactors / improves the existing code base).
- [ ] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Issues

I had an issue with Firefox during this task. Indeed, Firefox on MacOS uses Mac System Preferences to "allow" or not accessibility navigation, which is set to false by default. 

## How Has This Been Tested?

No new tests added. Previous ones passes. 

## Checklist:

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
