### PR TITLE
Mobile view fix

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,31 +8,20 @@ import { deviceBreakpoints } from "@src/design-system/theme";
 
 export const Layout: React.FC = ({ children }) => {
   return (
-    <Column>
-      <Main>
-        <MobileDisplayOnly>
-          <Header />
-          <MobileNavigationBar />
-        </MobileDisplayOnly>
-        <Flex>
-          <DesktopNavigationBarWrapper>
-            <DesktopNavigationBar />
-          </DesktopNavigationBarWrapper>
-          <ChildrenContainer>{children}</ChildrenContainer>
-        </Flex>
-      </Main>
+    <Main>
       <MobileDisplayOnly>
-        <MobileNavigationSpaceSimulator />
+        <Header />
+        <MobileNavigationBar />
       </MobileDisplayOnly>
-    </Column>
+      <Flex>
+        <DesktopNavigationBarWrapper>
+          <DesktopNavigationBar />
+        </DesktopNavigationBarWrapper>
+        <ChildrenContainer>{children}</ChildrenContainer>
+      </Flex>
+    </Main>
   );
 };
-
-const Column = styled.div`
-  display: flex;
-  flex-direction: column;
-  max-height: 100vh;
-`;
 
 export const Main = styled.main`
   width: 100%;
@@ -41,7 +30,8 @@ export const Main = styled.main`
   margin: 0 auto;
 
   @media ${deviceBreakpoints.m} {
-    overflow: scroll;
+    height: auto;
+    margin: 0 0 7.2rem 0;
   }
 `;
 
@@ -73,9 +63,4 @@ const MobileDisplayOnly = styled.div`
   @media ${deviceBreakpoints.m} {
     display: block;
   }
-`;
-
-const MobileNavigationSpaceSimulator = styled.div`
-  width: 100%;
-  height: 7.2rem;
 `;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -12,6 +12,7 @@ export const Layout: React.FC = ({ children }) => {
       <Main>
         <MobileDisplayOnly>
           <Header />
+          <MobileNavigationBar />
         </MobileDisplayOnly>
         <Flex>
           <DesktopNavigationBarWrapper>
@@ -21,7 +22,7 @@ export const Layout: React.FC = ({ children }) => {
         </Flex>
       </Main>
       <MobileDisplayOnly>
-        <MobileNavigationBar />
+        <MobileNavigationSpaceSimulator />
       </MobileDisplayOnly>
     </Column>
   );
@@ -72,4 +73,9 @@ const MobileDisplayOnly = styled.div`
   @media ${deviceBreakpoints.m} {
     display: block;
   }
+`;
+
+const MobileNavigationSpaceSimulator = styled.div`
+  width: 100%;
+  height: 7.2rem;
 `;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,20 +8,30 @@ import { deviceBreakpoints } from "@src/design-system/theme";
 
 export const Layout: React.FC = ({ children }) => {
   return (
-    <Main>
+    <Column>
+      <Main>
+        <MobileDisplayOnly>
+          <Header />
+        </MobileDisplayOnly>
+        <Flex>
+          <DesktopNavigationBarWrapper>
+            <DesktopNavigationBar />
+          </DesktopNavigationBarWrapper>
+          <ChildrenContainer>{children}</ChildrenContainer>
+        </Flex>
+      </Main>
       <MobileDisplayOnly>
-        <Header />
         <MobileNavigationBar />
       </MobileDisplayOnly>
-      <Flex>
-        <DesktopNavigationBarWrapper>
-          <DesktopNavigationBar />
-        </DesktopNavigationBarWrapper>
-        <ChildrenContainer>{children}</ChildrenContainer>
-      </Flex>
-    </Main>
+    </Column>
   );
 };
+
+const Column = styled.div`
+  display: flex;
+  flex-direction: column;
+  max-height: 100vh;
+`;
 
 export const Main = styled.main`
   width: 100%;
@@ -30,8 +40,6 @@ export const Main = styled.main`
   margin: 0 auto;
 
   @media ${deviceBreakpoints.m} {
-    height: auto;
-    max-height: calc(100vh - 7.2rem);
     overflow: scroll;
   }
 `;

--- a/src/components/display/fewlines/MobileNavigationBar/MobileNavigationBar.tsx
+++ b/src/components/display/fewlines/MobileNavigationBar/MobileNavigationBar.tsx
@@ -103,6 +103,9 @@ export const MobileNavigationBar: React.FC = () => {
 };
 
 const Container = styled.div`
+  position: fixed;
+  bottom: 0;
+  left: 0;
   width: 100%;
   z-index: 2;
   display: none;

--- a/src/components/display/fewlines/MobileNavigationBar/MobileNavigationBar.tsx
+++ b/src/components/display/fewlines/MobileNavigationBar/MobileNavigationBar.tsx
@@ -103,9 +103,6 @@ export const MobileNavigationBar: React.FC = () => {
 };
 
 const Container = styled.div`
-  position: fixed;
-  bottom: 0;
-  left: 0;
   width: 100%;
   z-index: 2;
   display: none;


### PR DESCRIPTION
## Description
This PR aims to fix the issue of the part of the content hidden by the `<MobileNavigationBar />`
<!--- Include a summary of the changes, which issue is fixed and, relevant motivation and context -->
- I added a `margin-bottom: 7.2rem;` to `<Main />`
It is better to do it this way rather than giving `<Main />` a `max-height: calc(100vh - 7.2rem);` property because on some screens it could have an OS navigation bar that could interfere with this calculation and create a gap
## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [ ] **Chore** (non-breaking change which refactors / improves the existing code base).
- [x] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Issues

<!--- Use this section if you had issues that led you to some workaround, otherwise the section can be removed -->

## How Has This Been Tested?
I modified tests imports only
<!---
Please describe the tests that you ran to verify your changes.
If needed, provide instructions, so we can reproduce (i.e. test configuration).
-->

## List of added dependencies

<!--- if appropriate, otherwise the section can be removed -->

## Screenshots

<!--- if appropriate, otherwise the section can be removed -->

## Checklist:

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
