### PR TITLE
fetching mongoDB to get refresh_token

### DIFF
--- a/src/middlewares/withAuth.ts
+++ b/src/middlewares/withAuth.ts
@@ -1,6 +1,8 @@
 import { HttpStatus } from "@fwl/web";
 import { ServerResponse } from "http";
+import { ObjectId } from "mongodb";
 
+import { MongoUser } from "@lib/@types";
 import { refreshTokensFlow } from "@lib/commands/refreshTokensFlow";
 import { ExtendedRequest } from "@src/@types/ExtendedRequest";
 import { Handler } from "@src/@types/Handler";
@@ -13,19 +15,23 @@ export function withAuth(handler: Handler): Handler {
     response: ServerResponse,
   ): Promise<unknown> => {
     const userDocumentId = request.session.get("user-session-id");
-    const user = request.session.get("user-session");
+    const userSession = request.session.get("user-session");
 
-    if (user) {
+    const user = await request.mongoDb.collection("users").findOne<MongoUser>({
+      _id: new ObjectId(userDocumentId),
+    });
+
+    if (userSession && user) {
       try {
         await oauth2Client
           .verifyJWT<{ sub: string }>(
-            user.access_token,
+            userSession.access_token,
             config.connectJwtAlgorithm,
           )
           .catch(async (error) => {
             if (error.name === "TokenExpiredError") {
               const { refresh_token, access_token } = await refreshTokensFlow(
-                user.refreshToken,
+                user.refresh_token,
               );
 
               await updateAccessAndRefreshTokens(


### PR DESCRIPTION
## Description

<!--- Include a summary of the changes, which issue is fixed and, relevant motivation and context -->
Since changes on access_token storage in cookie session, we lost access to refresh token in auth middleware when needing to refresh it. This PR fix this by fetching again mongoDB persistance.

## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [ ] **Chore** (non-breaking change which refactors / improves the existing code base).
- [x] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## How Has This Been Tested?

<!---
Please describe the tests that you ran to verify your changes.
If needed, provide instructions, so we can reproduce (i.e. test configuration).
-->

## Checklist:

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
