### PR TITLE
Check for uri presence before adding to management

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -38,10 +38,3 @@ jobs:
         CONNECT_MANAGEMENT_URL: ${{ secrets.CONNECT_MANAGEMENT_URL }}
         CONNECT_MANAGEMENT_API_KEY: ${{ secrets.CONNECT_MANAGEMENT_API_KEY }}
       run: yarn e2e-add-redirect-uri
-
-    - name: removing Vercel URL to Application's redirect uris
-      env:
-        CONNECT_ACCOUNT_TEST_APP_ID: ${{ secrets.CONNECT_ACCOUNT_TEST_APP_ID }}
-        CONNECT_MANAGEMENT_URL: ${{ secrets.CONNECT_MANAGEMENT_URL }}
-        CONNECT_MANAGEMENT_API_KEY: ${{ secrets.CONNECT_MANAGEMENT_API_KEY }}
-      run: yarn e2e-remove-redirect-uri

--- a/bin/add-redirect-uri-to-connect.ts
+++ b/bin/add-redirect-uri-to-connect.ts
@@ -37,13 +37,16 @@ async function addRedirectURIToConnect(): Promise<void> {
       return data.provider.application;
     });
 
+    const vercelDeploymentUrl =
+      vercelDeployment.target_url + "/api/oauth/callback";
+
     if (
       !vercelDeployment.target_url.includes("storybook") &&
-      !testApp.redirectUris.includes(vercelDeployment.target_url)
+      !testApp.redirectUris.includes(vercelDeploymentUrl)
     ) {
       const updatedTestApp = {
         ...testApp,
-        redirectUris: [...testApp.redirectUris, vercelDeployment.target_url],
+        redirectUris: [...testApp.redirectUris, vercelDeploymentUrl],
       };
 
       await updateApplication(updatedTestApp).then(({ errors, data }) => {


### PR DESCRIPTION
## Description

This PR aims to change the scripts implemented in GH action `e2e-tests`. 

* `remove-redirect-uri-from-connect` is no more launched in the action
* in `add-redirect-uri-to-connect`, the management fetch for Application infos is now done on severals `deployment_status.state` *(pending, success, in_progress, queued)*, and the Application's update occurs only if the action is triggered by a `connect-account` deployment event and if the current deployment url isn't already in the Application's redirect_uris.

## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] **Chore** (non-breaking change which refactors / improves the existing code base).
- [ ] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
