### PR TITLE
Adding a new identity & marking it as primary directly

### DIFF
--- a/src/@types/TemporaryIdentity.ts
+++ b/src/@types/TemporaryIdentity.ts
@@ -5,10 +5,12 @@ export type TemporaryIdentity = {
   value: string;
   type: string;
   expiresAt: number;
+  primary: boolean;
 };
 
 export type InMemoryTemporaryIdentity = {
   value: string;
   type: IdentityTypes;
   expiresAt: number;
+  primary: boolean;
 };

--- a/src/clientErrors.ts
+++ b/src/clientErrors.ts
@@ -8,6 +8,10 @@ export class NoIdentityFound extends Error {
   readonly message = "No Identity Found";
 }
 
+export class NoIdentityAdded extends Error {
+  readonly message = "No Identity Added";
+}
+
 export class IdentityAlreadyUsed extends Error {
   readonly message: string;
 

--- a/src/components/display/fewlines/AddIdentityForm/AddIdentityForm.tsx
+++ b/src/components/display/fewlines/AddIdentityForm/AddIdentityForm.tsx
@@ -77,9 +77,11 @@ export const AddIdentityForm: React.FC<AddIdentityFormProps> = ({
             });
           }}
         />
-        <Flex>
+
+        <Label>
           <Input
             type="checkbox"
+            name="primary"
             onChange={() => {
               setIdentity({
                 ...identity,
@@ -87,8 +89,8 @@ export const AddIdentityForm: React.FC<AddIdentityFormProps> = ({
               });
             }}
           />
-          <p>Marking this identity as my primary one</p>
-        </Flex>
+          Mark this identity as my primary one
+        </Label>
 
         <Button
           variant={ButtonVariant.PRIMARY}
@@ -109,9 +111,7 @@ const WrongInputError = styled.p`
   margin-bottom: 3rem;
 `;
 
-const Flex = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: left;
+const Label = styled.label`
+  display: block;
   margin-bottom: ${({ theme }) => theme.spaces.xs};
 `;

--- a/src/components/display/fewlines/AddIdentityForm/AddIdentityForm.tsx
+++ b/src/components/display/fewlines/AddIdentityForm/AddIdentityForm.tsx
@@ -114,4 +114,5 @@ const WrongInputError = styled.p`
 const Label = styled.label`
   display: block;
   margin-bottom: ${({ theme }) => theme.spaces.xs};
+  cursor: pointer;
 `;

--- a/src/components/display/fewlines/AddIdentityForm/AddIdentityForm.tsx
+++ b/src/components/display/fewlines/AddIdentityForm/AddIdentityForm.tsx
@@ -30,6 +30,7 @@ export const AddIdentityForm: React.FC<AddIdentityFormProps> = ({
     value: "",
     type,
     expiresAt: Date.now(),
+    primary: false,
   });
 
   return (
@@ -72,9 +73,23 @@ export const AddIdentityForm: React.FC<AddIdentityFormProps> = ({
               value: event.target.value,
               type,
               expiresAt: Date.now() + 300,
+              primary: identity.primary,
             });
           }}
         />
+        <Flex>
+          <Input
+            type="checkbox"
+            onChange={() => {
+              setIdentity({
+                ...identity,
+                primary: !identity.primary,
+              });
+            }}
+          />
+          <p>Marking this identity as my primary one</p>
+        </Flex>
+
         <Button
           variant={ButtonVariant.PRIMARY}
           type="submit"
@@ -92,4 +107,11 @@ const WrongInputError = styled.p`
   color: ${({ theme }) => theme.colors.red};
   font-weight: ${({ theme }) => theme.fontWeights.medium};
   margin-bottom: 3rem;
+`;
+
+const Flex = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: left;
+  margin-bottom: ${({ theme }) => theme.spaces.xs};
 `;

--- a/src/components/display/fewlines/Input/Input.tsx
+++ b/src/components/display/fewlines/Input/Input.tsx
@@ -13,4 +13,11 @@ export const Input = styled.input`
     color: ${({ theme }) => theme.colors.lightGrey};
     font-size: ${({ theme }) => theme.fontSizes.s};
   }
+
+  &[type="checkbox"] {
+    width: 18px;
+    height: 1.6rem;
+    margin: 0 ${({ theme }) => theme.spaces.xxs} 0 0;
+    cursor: pointer;
+  }
 `;

--- a/src/pages/api/auth-connect/send-identity-validation-code.ts
+++ b/src/pages/api/auth-connect/send-identity-validation-code.ts
@@ -53,6 +53,7 @@ const handler: Handler = async (request: ExtendedRequest, response) => {
           value: identityInput.value,
           type: identityInput.type,
           expiresAt: identityInput.expiresAt,
+          primary: identityInput.primary,
         };
 
         await insertTemporaryIdentity(userSession.sub, temporaryIdentity);

--- a/tests/pages/AddIdentityPage.test.tsx
+++ b/tests/pages/AddIdentityPage.test.tsx
@@ -90,9 +90,20 @@ describe("AddIdentityPage", () => {
       </AccountApp>,
     );
 
-    const addIdentityInput = component.find(Form).find(Input);
+    const addIdentityInput = component
+      .find(Form)
+      .find(Input)
+      .find('[type="email"]')
+      .hostNodes();
     expect(addIdentityInput).toHaveLength(1);
     expect(addIdentityInput.props().placeholder).toEqual("Enter your email");
+
+    const markAsPrimaryCheckbox = component
+      .find(Form)
+      .find(Input)
+      .find('[type="checkbox"]')
+      .hostNodes();
+    expect(markAsPrimaryCheckbox).toHaveLength(1);
 
     const addButton = component
       .find(Form)
@@ -116,9 +127,20 @@ describe("AddIdentityPage", () => {
       </AccountApp>,
     );
 
-    const addIdentityInput = component.find(Form).find(Input);
+    const addIdentityInput = component
+      .find(Form)
+      .find(Input)
+      .find('[type="text"]')
+      .hostNodes();
     expect(addIdentityInput).toHaveLength(1);
     expect(addIdentityInput.props().placeholder).toEqual("Enter your phone");
+
+    const markAsPrimaryCheckbox = component
+      .find(Form)
+      .find(Input)
+      .find('[type="checkbox"]')
+      .hostNodes();
+    expect(markAsPrimaryCheckbox).toHaveLength(1);
 
     const addButton = component
       .find(Form)
@@ -144,7 +166,10 @@ describe("AddIdentityPage", () => {
       </AccountApp>,
     );
 
-    const newIdentityInput = component.find(Input);
+    const newIdentityInput = component
+      .find(Input)
+      .find('[type="email"]')
+      .hostNodes();
 
     newIdentityInput.simulate("change", {
       target: { value: "test3@test.test " },
@@ -163,6 +188,7 @@ describe("AddIdentityPage", () => {
         callbackUrl: "/",
         identityInput: {
           expiresAt: 1572393600000 + 300,
+          primary: false,
           type: IdentityTypes.EMAIL,
           value: "test3@test.test ",
         },


### PR DESCRIPTION
## Description

<!--- Include a summary of the changes, which issue is fixed and, relevant motivation and context -->
This PR adds the possibility for user to add a new identity and marking it as primary directly. 
To do so, a checkbox input was added beneath identity input in the form. 
A new field `primary: boolean` was added to `InMemoryTemporaryIdentity` & `TemporaryIdentity` which is added in our persistence database, this new field reflects if a new identity needs to be `markIdentityAsPrimary` after its creation on Management side. 

## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [ ] **Chore** (non-breaking change which refactors / improves the existing code base).
- [ ] **Bug fix** (non-breaking change which fixes an issue).
- [x] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## How Has This Been Tested?

<!---
Please describe the tests that you ran to verify your changes.
If needed, provide instructions, so we can reproduce (i.e. test configuration).
-->
Updated exisiting test suit, and added new assertions to check presence of the new checkbox in the form.

## Checklist:

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
