### PR TITLE
Refacto e2e utils and added navigation timeout

### DIFF
--- a/tests/e2e/desktop-navigation-bar.test.ts
+++ b/tests/e2e/desktop-navigation-bar.test.ts
@@ -1,14 +1,13 @@
 import {
   openBrowser,
   closeBrowser,
-  goto,
   text,
   click,
   screenshot,
   waitFor,
 } from "taiko";
 
-import { authToConnect } from "./utils/authToConnect";
+import { authenticateToConnect } from "./utils/authenticateToConnect";
 
 describe("DesktopNavigationBar", () => {
   jest.setTimeout(60000);
@@ -25,9 +24,7 @@ describe("DesktopNavigationBar", () => {
     expect.assertions(6);
 
     try {
-      await goto("http://localhost:29703");
-
-      await authToConnect();
+      await authenticateToConnect();
 
       await waitFor("Logins");
       expect(await text("Logins").exists()).toBeTruthy();

--- a/tests/e2e/fill-incorrect-identity-input-values.test.ts
+++ b/tests/e2e/fill-incorrect-identity-input-values.test.ts
@@ -11,7 +11,7 @@ import {
   textBox,
 } from "taiko";
 
-import { authToConnect } from "./utils/authToConnect";
+import { authenticateToConnect } from "./utils/authenticateToConnect";
 import { config } from "@src/config";
 
 describe("Account Web Application update password", () => {
@@ -29,9 +29,7 @@ describe("Account Web Application update password", () => {
     expect.assertions(9);
 
     try {
-      await goto(config.connectAccountURL);
-
-      await authToConnect();
+      await authenticateToConnect();
 
       await waitFor("LOGINS");
       expect(await text("LOGINS").exists()).toBeTruthy();

--- a/tests/e2e/fill-incorrect-new-password.test.ts
+++ b/tests/e2e/fill-incorrect-new-password.test.ts
@@ -1,7 +1,6 @@
 import {
   openBrowser,
   closeBrowser,
-  goto,
   text,
   click,
   write,
@@ -12,7 +11,7 @@ import {
   clear,
 } from "taiko";
 
-import { authToConnect } from "./utils/authToConnect";
+import { authenticateToConnect } from "./utils/authenticateToConnect";
 
 describe("Account Web Application update password", () => {
   jest.setTimeout(60000);
@@ -29,9 +28,7 @@ describe("Account Web Application update password", () => {
     expect.assertions(11);
 
     try {
-      await goto("http://localhost:29703");
-
-      await authToConnect();
+      await authenticateToConnect();
 
       await waitFor("SECURITY");
       expect(await text("SECURITY").exists()).toBeTruthy();

--- a/tests/e2e/mark-identity-as-primary.test.ts
+++ b/tests/e2e/mark-identity-as-primary.test.ts
@@ -1,7 +1,6 @@
 import {
   openBrowser,
   closeBrowser,
-  goto,
   text,
   click,
   screenshot,
@@ -11,7 +10,7 @@ import {
   above,
 } from "taiko";
 
-import { authToConnect } from "./utils/authToConnect";
+import { authenticateToConnect } from "./utils/authenticateToConnect";
 
 describe("Marking another identity as the primary one on connect account", () => {
   jest.setTimeout(60000);
@@ -28,9 +27,7 @@ describe("Marking another identity as the primary one on connect account", () =>
     expect.assertions(9);
 
     try {
-      await goto("http://localhost:29703");
-
-      await authToConnect();
+      await authenticateToConnect();
 
       await waitFor("LOGINS");
       expect(await text("LOGINS").exists()).toBeTruthy();

--- a/tests/e2e/mobile-navigation-bar.test.ts
+++ b/tests/e2e/mobile-navigation-bar.test.ts
@@ -1,14 +1,13 @@
 import {
   openBrowser,
   closeBrowser,
-  goto,
   text,
   click,
   screenshot,
   waitFor,
 } from "taiko";
 
-import { authToConnect } from "./utils/authToConnect";
+import { authenticateToConnect } from "./utils/authenticateToConnect";
 
 describe("Log in with a smart phone, open and close the navigation bar", () => {
   jest.setTimeout(60000);
@@ -25,9 +24,7 @@ describe("Log in with a smart phone, open and close the navigation bar", () => {
     expect.assertions(7);
 
     try {
-      await goto("http://localhost:29703");
-
-      await authToConnect();
+      await authenticateToConnect();
 
       await waitFor("Menu");
       expect(await text("Menu").exists()).toBeTruthy();

--- a/tests/e2e/show-identity.test.ts
+++ b/tests/e2e/show-identity.test.ts
@@ -1,7 +1,6 @@
 import {
   openBrowser,
   closeBrowser,
-  goto,
   text,
   click,
   screenshot,
@@ -10,7 +9,7 @@ import {
   below,
 } from "taiko";
 
-import { authToConnect } from "./utils/authToConnect";
+import { authenticateToConnect } from "./utils/authenticateToConnect";
 
 describe("Account Web Application show identity", () => {
   jest.setTimeout(60000);
@@ -27,9 +26,7 @@ describe("Account Web Application show identity", () => {
     expect.assertions(6);
 
     try {
-      await goto("http://localhost:29703");
-
-      await authToConnect();
+      await authenticateToConnect();
 
       await waitFor("LOGINS");
       expect(await text("LOGINS").exists()).toBeTruthy();

--- a/tests/e2e/utils/authenticateToConnect.ts
+++ b/tests/e2e/utils/authenticateToConnect.ts
@@ -1,9 +1,11 @@
-import { text, click, screenshot, waitFor, write, press } from "taiko";
+import { text, click, screenshot, waitFor, write, press, goto } from "taiko";
 
 import { config } from "@src/config";
 
-export async function authToConnect(): Promise<void> {
+export async function authenticateToConnect(): Promise<void> {
   try {
+    await goto(config.connectAccountURL);
+
     await waitFor("Access my account");
     expect(await text("Access my account").exists()).toBeTruthy();
     await click("Access my account");
@@ -16,10 +18,10 @@ export async function authToConnect(): Promise<void> {
     await waitFor("Password");
     expect(await text("Password").exists()).toBeTruthy();
     await write(config.connectTestAccountPassword);
-    await press("Enter");
+    await press("Enter", { navigationTimeout: 60000 });
   } catch (error) {
     await screenshot({
-      path: "tests/e2e/screenshots/auth-to-connect.png",
+      path: "tests/e2e/screenshots/authenticate-to-connect.png",
     });
 
     throw error;


### PR DESCRIPTION
## Description

This PR aims at adding a navigation timeout to prevent random e2e test failure.

I also refactored the authentification util functions.

## Type of change

- [x] **Chore** (non-breaking change which refactors / improves the existing code base).
- [x] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).
- [ ] ## How Has This Been Tested?

Manually.

## Checklist:

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [ ] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
