### PR TITLE
Revamp ValidateIdentityPage test with RTL

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@storybook/react": "6.1.7",
     "@testing-library/jest-dom": "5.11.8",
     "@testing-library/react": "11.2.2",
+    "@testing-library/user-event": "12.6.0",
     "@types/enzyme": "3.10.8",
     "@types/enzyme-adapter-react-16": "1.0.6",
     "@types/jest": "26.0.15",

--- a/src/components/display/fewlines/Icons/CrossIcon/CrossIcon.tsx
+++ b/src/components/display/fewlines/Icons/CrossIcon/CrossIcon.tsx
@@ -3,6 +3,7 @@ import React from "react";
 export const CrossIcon: React.FC = () => {
   return (
     <svg width="14" height="14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <title>Closing cross</title>
       <path
         d="M14 1.41L12.59 0 7 5.59 1.41 0 0 1.41 5.59 7 0 12.59 1.41 14 7 8.41 12.59 14 14 12.59 8.41 7 14 1.41z"
         fill="#fff"

--- a/tests/config/testing-library-config.tsx
+++ b/tests/config/testing-library-config.tsx
@@ -5,6 +5,19 @@ import React from "react";
 
 import { AccountApp } from "@src/pages/_app.tsx";
 
+const mockLink = ({
+  children,
+  ...props
+}: {
+  children: JSX.Element;
+}): JSX.Element => {
+  return React.cloneElement(children, props);
+};
+
+jest.mock("next/link", () => {
+  return mockLink;
+});
+
 const mockedNextRouter: NextRouter = {
   basePath: "",
   pathname: "/",
@@ -15,7 +28,7 @@ const mockedNextRouter: NextRouter = {
   replace: jest.fn(),
   reload: jest.fn(),
   back: jest.fn(),
-  prefetch: jest.fn().mockResolvedValue(undefined),
+  prefetch: jest.fn().mockResolvedValue(null),
   beforePopState: jest.fn(),
   events: {
     on: jest.fn(),

--- a/tests/pages/LoginsOverviewPage.test.tsx
+++ b/tests/pages/LoginsOverviewPage.test.tsx
@@ -81,7 +81,7 @@ describe("LoginsOverviewPage", () => {
       );
       const alertBar = component.find(AlertBar);
       expect(alertBar).toHaveLength(1);
-      expect(alertBar.text()).toEqual("Email address has been deleted");
+      expect(alertBar.text()).toContain("Email address has been deleted");
     });
 
     test("it should display email, phone and social identities if there are one of each", () => {

--- a/tests/pages/ValidateIdentityPage.test.tsx
+++ b/tests/pages/ValidateIdentityPage.test.tsx
@@ -5,6 +5,16 @@ import { render, screen } from "../config/testing-library-config";
 import { IdentityTypes } from "@lib/@types/Identity";
 import ValidateIdentityPage from "@src/pages/account/logins/[type]/validation/[eventId]";
 
+jest.mock("@src/dbClient", () => {
+  return {
+    dynamoDbClient: {
+      send: () => {
+        return;
+      },
+    },
+  };
+});
+
 const eventId = "foo";
 
 const alertBarMessages = {

--- a/tests/pages/ValidateIdentityPage.test.tsx
+++ b/tests/pages/ValidateIdentityPage.test.tsx
@@ -1,144 +1,129 @@
-import { mount } from "enzyme";
-import { enableFetchMocks } from "jest-fetch-mock";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 
+import { render, screen } from "../config/testing-library-config";
 import { IdentityTypes } from "@lib/@types/Identity";
-import AlertBar from "@src/components/display/fewlines/AlertBar/AlertBar";
-import { Button } from "@src/components/display/fewlines/Button/Button";
-import { FakeButton } from "@src/components/display/fewlines/FakeButton/FakeButton";
-import { Input } from "@src/components/display/fewlines/Input/Input";
-import {
-  NavigationBreadcrumbs,
-  Breadcrumbs,
-} from "@src/components/display/fewlines/NavigationBreadcrumbs/NavigationBreadcrumbs";
-import { AccountApp } from "@src/pages/_app";
 import ValidateIdentityPage from "@src/pages/account/logins/[type]/validation/[eventId]";
 
-enableFetchMocks();
+const eventId = "foo";
 
-jest.mock("@src/config", () => {
-  return {
-    config: {
-      connectApplicationClientSecret: "foo-bar",
-      connectAccountSessionSalt: ".*b+x3ZXE3-h[E+Q5YC5`jr~y%CA~R-[",
-    },
-  };
-});
-
-jest.mock("@src/dbClient", () => {
-  return {
-    dynamoDbClient: {
-      send: () => {
-        return;
-      },
-    },
-  };
-});
+const alertBarMessages = {
+  email: "Confirmation email has been sent",
+  phone: "Confirmation SMS has been sent",
+};
 
 describe("ValidateIdentityPage", () => {
-  const eventId = "foo";
+  describe("Identity type : EMAIL", () => {
+    it("should display proper email alert message", async () => {
+      render(
+        <ValidateIdentityPage type={IdentityTypes.EMAIL} eventId={eventId} />,
+      );
 
-  test("it should display navigation breadcrumbs properly for emails", () => {
-    const component = mount(
-      <AccountApp>
-        <ValidateIdentityPage type={IdentityTypes.EMAIL} eventId={eventId} />
-      </AccountApp>,
-    );
+      expect.assertions(3);
 
-    const navigationBreadCrumbs = component.find(NavigationBreadcrumbs);
-    expect(navigationBreadCrumbs).toHaveLength(1);
-    expect(
-      navigationBreadCrumbs.contains(
-        <Breadcrumbs>Email address | validation</Breadcrumbs>,
-      ),
-    ).toEqual(true);
+      expect(
+        await screen.findByText(alertBarMessages.email),
+      ).toBeInTheDocument();
+
+      expect(await screen.findByTitle("Closing cross")).toBeInTheDocument();
+      userEvent.click(screen.getByTitle("Closing cross"));
+
+      expect(
+        screen.queryByText(alertBarMessages.email),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should render proper email form elements ", () => {
+      render(
+        <ValidateIdentityPage type={IdentityTypes.EMAIL} eventId={eventId} />,
+      );
+
+      const validationCodeInput = screen.getByRole("textbox");
+      expect(validationCodeInput).toBeVisible();
+      userEvent.type(validationCodeInput, "424242");
+      expect(validationCodeInput).toHaveDisplayValue("424242");
+
+      expect(
+        screen.getByRole("button", { name: "Confirm email" }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole("link", { name: "Discard all changes" }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole("link", { name: "Discard all changes" }),
+      ).toHaveAttribute("href", "/account/logins");
+
+      expect(
+        screen.getByRole("button", { name: "Resend confirmation code" }),
+      ).toBeInTheDocument();
+    });
+
+    it("should render proper email breadcrumbs", () => {
+      render(
+        <ValidateIdentityPage type={IdentityTypes.EMAIL} eventId={eventId} />,
+      );
+
+      expect(
+        screen.getByText("Email address | validation"),
+      ).toBeInTheDocument();
+    });
   });
 
-  test("it should display navigation breadcrumbs properly for phones", () => {
-    const component = mount(
-      <AccountApp>
-        <ValidateIdentityPage type={IdentityTypes.PHONE} eventId={eventId} />
-      </AccountApp>,
-    );
+  describe("Identity type : PHONE", () => {
+    it("should display proper phone alert message", async () => {
+      render(
+        <ValidateIdentityPage type={IdentityTypes.PHONE} eventId={eventId} />,
+      );
 
-    const navigationBreadCrumbs = component.find(NavigationBreadcrumbs);
-    expect(navigationBreadCrumbs).toHaveLength(1);
-    expect(
-      navigationBreadCrumbs.contains(
-        <Breadcrumbs>Phone number | validation</Breadcrumbs>,
-      ),
-    ).toEqual(true);
-  });
+      expect.assertions(3);
 
-  test("it should display an input and 3 buttons for emails", () => {
-    const component = mount(
-      <AccountApp>
-        <ValidateIdentityPage type={IdentityTypes.EMAIL} eventId={eventId} />
-      </AccountApp>,
-    );
+      expect(
+        await screen.findByText(alertBarMessages.phone),
+      ).toBeInTheDocument();
 
-    const validationCodeInput = component
-      .find(Input)
-      .find({ placeholder: "012345" })
-      .hostNodes();
+      expect(await screen.findByTitle("Closing cross")).toBeInTheDocument();
+      userEvent.click(screen.getByTitle("Closing cross"));
 
-    const buttons = component.find(Button);
+      expect(
+        screen.queryByText(alertBarMessages.phone),
+      ).not.toBeInTheDocument();
+    });
 
-    const fakeButton = component.find(FakeButton);
+    it("should render proper phone form elements ", () => {
+      render(
+        <ValidateIdentityPage type={IdentityTypes.PHONE} eventId={eventId} />,
+      );
 
-    expect(validationCodeInput).toHaveLength(1);
-    expect(buttons).toHaveLength(2);
-    expect(buttons.at(0).text()).toEqual("Confirm email");
-    expect(buttons.at(1).text()).toEqual("Resend confirmation code");
-    expect(fakeButton.text()).toEqual("Discard all changes");
-  });
+      const validationCodeInput = screen.getByRole("textbox");
+      expect(validationCodeInput).toBeVisible();
+      userEvent.type(validationCodeInput, "424242");
+      expect(validationCodeInput).toHaveDisplayValue("424242");
 
-  test("it should display properly an input and 3 buttons for phones", () => {
-    const component = mount(
-      <AccountApp>
-        <ValidateIdentityPage type={IdentityTypes.PHONE} eventId={eventId} />
-      </AccountApp>,
-    );
+      expect(
+        screen.getByRole("button", { name: "Confirm phone" }),
+      ).toBeInTheDocument();
 
-    const validationCodeInput = component
-      .find(Input)
-      .find({ placeholder: "012345" })
-      .hostNodes();
+      expect(
+        screen.getByRole("link", { name: "Discard all changes" }),
+      ).toBeInTheDocument();
 
-    const buttons = component.find(Button);
+      expect(
+        screen.getByRole("link", { name: "Discard all changes" }),
+      ).toHaveAttribute("href", "/account/logins");
 
-    const fakeButton = component.find(FakeButton);
+      expect(
+        screen.getByRole("button", { name: "Resend confirmation code" }),
+      ).toBeInTheDocument();
+    });
 
-    expect(validationCodeInput).toHaveLength(1);
-    expect(buttons).toHaveLength(2);
-    expect(buttons.at(0).text()).toEqual("Confirm phone");
-    expect(buttons.at(1).text()).toEqual("Resend confirmation code");
-    expect(fakeButton.text()).toEqual("Discard all changes");
-  });
+    it("should render proper phone breadcrumbs", () => {
+      render(
+        <ValidateIdentityPage type={IdentityTypes.PHONE} eventId={eventId} />,
+      );
 
-  test("it should display an alert bar with the correct message for phones", () => {
-    const component = mount(
-      <AccountApp>
-        <ValidateIdentityPage type={IdentityTypes.PHONE} eventId={eventId} />
-      </AccountApp>,
-    );
-
-    const alertBar = component.find(AlertBar);
-
-    expect(alertBar).toHaveLength(1);
-    expect(alertBar.text()).toEqual("Confirmation SMS has been sent");
-  });
-
-  test("it should display an alert bar with the correct message for emails", () => {
-    const component = mount(
-      <AccountApp>
-        <ValidateIdentityPage type={IdentityTypes.EMAIL} eventId={eventId} />
-      </AccountApp>,
-    );
-
-    const alertBar = component.find(AlertBar);
-
-    expect(alertBar).toHaveLength(1);
-    expect(alertBar.text()).toEqual("Confirmation email has been sent");
+      expect(screen.getByText("Phone number | validation")).toBeInTheDocument();
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3101,7 +3101,7 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
 
-"@testing-library/user-event@^12.6.0":
+"@testing-library/user-event@12.6.0":
   version "12.6.0"
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.6.0.tgz#2d0229e399eb5a0c6c112e848611432356cac886"
   integrity sha512-FNEH/HLmOk5GO70I52tKjs7WvGYckeE/SrnLX/ip7z2IGbffyd5zOUM1tZ10vsTphqm+VbDFI0oaXu0wcfQsAQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3101,6 +3101,13 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
 
+"@testing-library/user-event@^12.6.0":
+  version "12.6.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.6.0.tgz#2d0229e399eb5a0c6c112e848611432356cac886"
+  integrity sha512-FNEH/HLmOk5GO70I52tKjs7WvGYckeE/SrnLX/ip7z2IGbffyd5zOUM1tZ10vsTphqm+VbDFI0oaXu0wcfQsAQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"


### PR DESCRIPTION
## Description

<!--- Include a summary of the changes, which issue is fixed and, relevant motivation and context -->
This PR's goal was to rewrite `ValidateIdentityPage.test.tsx` to use `react-testing-library` instead of `enzyme`. Most of previous test cases have been kept, and some new added.

## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] **Chore** (non-breaking change which refactors / improves the existing code base).
- [ ] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Issues

<!--- Use this section if you had issues that led you to some workaround, otherwise the section can be removed -->

<img width="650" alt="error screenshot" src="https://user-images.githubusercontent.com/50053259/103801845-96a50380-504e-11eb-8dd8-b73cd194e2f3.png">

During the rewriting of the test suit (ie `ValidateIdentityPage.test.tsx`), this error rose up. After some tests, it seems to only happen when a minimum of two `describe()` blocks are present in the test file. When any of the two `describe()`blocks are runned alone, this error doesn't occur. 

As the error suggested, this is coming from `next/link` component, that I didn't mock in the first place. I tried different things inside the test suit itself (like running `cleanup()` with `beforeEach()` or `afterEach()` in and outside the `describe()` blocks, calling `render()` inside `act()` ...etc), unfortunately, none solved the issue.

The only workaround that solved this issue was to add a mock of `next/link` inside `testing-library-config.tsx`, where I had already added a mock for Next's Router before this issue. Here is the code :

```typescript
const mockLink = ({
  children,
  ...props
}: {
  children: JSX.Element;
}): JSX.Element => {
  return React.cloneElement(children, props);
};

jest.mock("next/link", () => {
  return mockLink;
});
```
In the first place, I only returned children inside the mock. But since Next's Link is a wrapper for anchor tag (`<Link><a>....</a></Link>`), the children anchor tag wasn't receiving anymore the `href` attribute, which might be an important attribute to test. So I ended up cloning the `children` prop (`<a>`) to be able to pass it the other props of `<Link>` component and to keep its original behaviour. 

## How Has This Been Tested?

<!---
Please describe the tests that you ran to verify your changes.
If needed, provide instructions, so we can reproduce (i.e. test configuration).
-->

Test suit.

## List of added dependencies

<!--- if appropriate, otherwise the section can be removed -->
* **@testing-library/user-event**, v12.6.0.

## Checklist:

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
