### PR TITLE
Fixed lock-icon

### DIFF
--- a/src/components/desktop-navigation-bar/desktop-navigation-bar.tsx
+++ b/src/components/desktop-navigation-bar/desktop-navigation-bar.tsx
@@ -45,8 +45,10 @@ const Bar = styled.div`
 const ListItem = styled(NeutralLink)`
   display: flex;
   align-items: center;
-  padding: ${({ theme }) => theme.spaces.xs} 0 ${({ theme }) => theme.spaces.xs}
-    ${({ theme }) => theme.spaces.xs};
+  padding-top: ${({ theme }) => theme.spaces.xs};
+  padding-bottom: ${({ theme }) => theme.spaces.xs};
+  padding-right: 0;
+  padding-left: ${({ theme }) => theme.spaces.xs};
 `;
 
 const ListLabel = styled.p`

--- a/src/components/icons/lock-icon/lock-icon.tsx
+++ b/src/components/icons/lock-icon/lock-icon.tsx
@@ -6,31 +6,31 @@ export const LockIcon: React.FC = () => {
   return (
     <NavigationBarIconContainer>
       <svg
-        width="25"
-        height="30"
+        width="40"
+        height="40"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
       >
         <rect
-          x="1"
-          y="11"
+          x="8"
+          y="15"
           width="23"
-          height="18"
-          rx="1"
+          height="19"
+          rx="2"
           stroke="#03083C"
           strokeWidth="2"
           strokeLinecap="round"
         />
         <circle
-          cx="12.885"
-          cy="18.885"
+          cx="19.885"
+          cy="22.885"
           r="1.885"
           stroke="#03083C"
           strokeWidth="2"
           strokeLinecap="round"
         />
         <path
-          d="M13 21v4M9 10V4c0-1 .7-3 3.5-3S16 3 16 4v6"
+          d="M20 25v4M16 14V8c0-1 .7-3 3.5-3S23 7 23 8v6"
           stroke="#03083C"
           strokeWidth="2"
           strokeLinecap="round"


### PR DESCRIPTION
## Description

This PR aims at fixing the square from the lock icon that disappear when zooming through the browser.

I also fixed a linter warning non a 4 value padding.

## Type of change

- [ ] **Chore** (non-breaking change which refactors / improves the existing code base).
- [x] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Issues

The icons size are inconsistent:

![image](https://user-images.githubusercontent.com/31956107/104508370-6af2c200-55e8-11eb-99bf-aa714c081d76.png)

I wrote a task to fix that.

## How Has This Been Tested?

Manually.

## Checklist:

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
