### PR TITLE
Better handling of deployment failure for e2e PR validation

### DIFF
--- a/bin/e2e/create-e2e-status-check.ts
+++ b/bin/e2e/create-e2e-status-check.ts
@@ -31,10 +31,14 @@ async function createE2eStatusCheck(): Promise<void> {
       check.name === "e2e-tests" && check.conclusion !== "skipped",
   );
 
+  const target_url = hasDeploymentFailed
+    ? githubActionsContext.deployment_status.target_url
+    : `https://github.com/fewlinesco/connect-account/pull/${e2eCheckRun[0].pull_requests[0].number}/checks?check_run_id=${e2eCheckRun[0].id}`;
+
   const statusCheckBody = {
     context: "e2e tests",
     state: hasDeploymentFailed ? "failure" : e2eCheckRun[0].conclusion,
-    target_url: `https://github.com/fewlinesco/connect-account/pull/${e2eCheckRun[0].pull_requests[0].number}/checks?check_run_id=${e2eCheckRun[0].id}`,
+    target_url,
   };
 
   await fetch(

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,8 @@ const config: Config = {
   },
 };
 
+process.exit(1);
+
 function handleEnvVars(): void {
   const appHostname =
     process.env.CONNECT_ACCOUNT_HOSTNAME ||

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,8 +60,6 @@ const config: Config = {
   },
 };
 
-process.exit(1);
-
 function handleEnvVars(): void {
   const appHostname =
     process.env.CONNECT_ACCOUNT_HOSTNAME ||


### PR DESCRIPTION
## Description

<!--- Include a summary of the changes, which issue is fixed and, relevant motivation and context -->
This PR aims at fixing a bug with e2e test status check when `deployment` failed, where the status check's `target_url` couldn't be set properly. (`target_url` is used by github for the "Details" link aside PR's check).

Fix: 
* If `deployment` has failed, we set the `target_url` to Heroku dashboard, where we can retry to launch deployment.
* If `deployment` succeed, we still set the `target_url` to the job page. 

## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [ ] **Chore** (non-breaking change which refactors / improves the existing code base).
- [x] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Screenshots

<!--- if appropriate, otherwise the section can be removed -->
4’’4
## Checklist:

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
