### PR TITLE
Fix update password flow

### DIFF
--- a/src/components/forms/set-password-form.tsx
+++ b/src/components/forms/set-password-form.tsx
@@ -40,20 +40,20 @@ const SetPasswordForm: React.FC<{
 
         if (isNotSubmitted) {
           if (passwordInput === passwordConfirmationInput) {
-            const { details: restrictionRules } = await setPassword(
+            const { isUpdated, details: restrictionRules } = await setPassword(
               passwordInput,
             );
 
             if (restrictionRules) {
               setPasswordRestrictionError(restrictionRules);
-
               setIsNotSubmitted(true);
-            } else {
+            }
+
+            if (isUpdated) {
               router && router.push("/account/security");
             }
           } else {
             setIsNotSubmitted(true);
-
             setPasswordsNotMatching(true);
           }
         }

--- a/src/pages/api/auth-connect/set-password.ts
+++ b/src/pages/api/auth-connect/set-password.ts
@@ -53,12 +53,12 @@ const handler: Handler = async (request, response) => {
       cleartextPassword: passwordInput,
       userId: userCookie.sub,
     })
-      .then(() => {
+      .then((isUpdated) => {
         span.setDisclosedAttribute("password created or updated", true);
 
         response.setHeader("Content-Type", "application/json");
         response.statusCode = HttpStatus.OK;
-        response.end();
+        response.json({ isUpdated });
         return;
       })
       .catch((error) => {

--- a/src/workflows/set-password.ts
+++ b/src/workflows/set-password.ts
@@ -5,6 +5,7 @@ import { ErrorSettingPassword } from "@src/errors";
 import { fetchJson } from "@src/utils/fetch-json";
 
 type SetPasswordOutput = {
+  isUpdated?: boolean;
   details?: PasswordRules;
 };
 


### PR DESCRIPTION
## Description

<!--- Include a summary of the changes, which issue is fixed and, relevant motivation and context -->

This PR tries to fix these Sentry errors : [1](https://sentry.io/organizations/fewlines/issues/2231535588/?project=5387583) - [2](https://sentry.io/organizations/fewlines/issues/2231433473/?project=5387583). 
It was caused by the fact that in update password flow, the Response's body was empty when the GraphQL command succeeded, and `response.json()` failed. So, now we send back to the client the boolean value from GraphQL command if restriction rules are fulfilled, otherwise we send back these ones.  

## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [ ] **Chore** (non-breaking change which refactors / improves the existing code base).
- [x] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
