### PR TITLE
Fixing color of safari icon

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -70,7 +70,7 @@ export default class MyDocument extends Document {
             href="/favicon-16x16.png"
           />
           <link rel="manifest" href="/site.webmanifest" />
-          <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
+          <link rel="mask-icon" href="/safari-pinned-tab.svg" />
           <meta name="theme-color" content="#ffffff" />
           <meta
             name="description"


### PR DESCRIPTION
## Description

<!--- Include a summary of the changes, which issue is fixed and, relevant motivation and context -->
This PR fixes a color issue on the Safari favicon.

## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [ ] **Chore** (non-breaking change which refactors / improves the existing code base).
- [x] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Screenshots

<!--- if appropriate, otherwise the section can be removed -->
Before : 
<img width="376" alt="image" src="https://user-images.githubusercontent.com/50053259/110464878-fb72ed80-80d3-11eb-9384-7f1cd80360ee.png">

Now: 
<img width="233" alt="image" src="https://user-images.githubusercontent.com/50053259/110464917-0af23680-80d4-11eb-8afa-f1586ffa4924.png">


## Checklist:

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
