### PR TITLE
Fine tuned hard-coded 400 into HTTP_STATUS.NOT_FOUND

### DIFF
--- a/src/pages/account/logins/[type]/[id]/index.tsx
+++ b/src/pages/account/logins/[type]/[id]/index.tsx
@@ -5,7 +5,7 @@ import {
   Identity,
   IdentityTypes,
 } from "@fewlines/connect-management";
-import { getServerSideCookies } from "@fwl/web";
+import { getServerSideCookies, HttpStatus } from "@fwl/web";
 import {
   loggingMiddleware,
   tracingMiddleware,
@@ -68,7 +68,7 @@ const getServerSideProps: GetServerSideProps = async (context) => {
     "/account/logins/[type]/[id]",
     async (request, response) => {
       if (!context?.params?.id) {
-        response.statusCode = 400;
+        response.statusCode = HttpStatus.NOT_FOUND;
         response.end();
         return;
       }

--- a/src/pages/account/logins/[type]/[id]/update.tsx
+++ b/src/pages/account/logins/[type]/[id]/update.tsx
@@ -5,7 +5,7 @@ import {
   GraphqlErrors,
   ConnectUnreachableError,
 } from "@fewlines/connect-management";
-import { getServerSideCookies } from "@fwl/web";
+import { getServerSideCookies, HttpStatus } from "@fwl/web";
 import {
   loggingMiddleware,
   tracingMiddleware,
@@ -65,7 +65,7 @@ const getServerSideProps: GetServerSideProps = async (context) => {
     "/account/logins/[type]/[id]/update",
     async (request, response) => {
       if (!context?.params?.id) {
-        response.statusCode = 400;
+        response.statusCode = HttpStatus.NOT_FOUND;
         response.end();
         return;
       }

--- a/src/pages/account/logins/[type]/new.tsx
+++ b/src/pages/account/logins/[type]/new.tsx
@@ -1,4 +1,5 @@
 import { IdentityTypes } from "@fewlines/connect-management";
+import { HttpStatus } from "@fwl/web";
 import {
   loggingMiddleware,
   tracingMiddleware,
@@ -55,7 +56,7 @@ const getServerSideProps: GetServerSideProps = async (context) => {
     "/account/logins/[type]/new",
     async () => {
       if (!context?.params?.type) {
-        context.res.statusCode = 400;
+        context.res.statusCode = HttpStatus.NOT_FOUND;
         context.res.end();
         return;
       }

--- a/src/pages/account/logins/[type]/validation/[eventId].tsx
+++ b/src/pages/account/logins/[type]/validation/[eventId].tsx
@@ -1,5 +1,5 @@
 import { IdentityTypes } from "@fewlines/connect-management";
-import { AlertMessage, getServerSideCookies } from "@fwl/web";
+import { AlertMessage, getServerSideCookies, HttpStatus } from "@fwl/web";
 import {
   loggingMiddleware,
   tracingMiddleware,
@@ -61,12 +61,12 @@ const getServerSideProps: GetServerSideProps = async (context) => {
     "/account/logins/[type]/validation/[eventId]",
     async (request, response: ServerResponse) => {
       if (!context?.params?.type) {
-        response.statusCode = 400;
+        response.statusCode = HttpStatus.NOT_FOUND;
         response.end();
         return;
       }
       if (!context?.params?.eventId) {
-        response.statusCode = 400;
+        response.statusCode = HttpStatus.NOT_FOUND;
         response.end();
         return;
       }


### PR DESCRIPTION
## Description

This PR aims at using the `HTTP_STATUS` enum where some `400` were hard coded. After reading about `422` and `400`, I found that it was not really our usage here.

These conditions are just here for TypeScript.

## Type of change

- [x] **Chore** (non-breaking change which refactors / improves the existing code base).
- [ ] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
