### PR TITLE
Migrate alert messages outside the layout + fix

### DIFF
--- a/src/components/alert-message/alert-messages.tsx
+++ b/src/components/alert-message/alert-messages.tsx
@@ -30,13 +30,22 @@ const AlertMessages: React.FC<{
 
 const AlertMessage: React.FC<{ text: string }> = ({ text }) => {
   const [showAlertMessage, setShowAlertMessage] = React.useState<boolean>(true);
+  const animationDuration = 3;
+
+  React.useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setShowAlertMessage(false);
+    }, animationDuration * 1000);
+
+    return () => clearTimeout(timeoutId);
+  }, []);
 
   if (!showAlertMessage) {
     return null;
   }
 
   return (
-    <Alert>
+    <Alert animationDuration={animationDuration}>
       <p>{text}</p>
       <div className="cross" onClick={() => setShowAlertMessage(false)}>
         <CrossIcon />
@@ -47,12 +56,15 @@ const AlertMessage: React.FC<{ text: string }> = ({ text }) => {
 
 const Wrapper = styled.div`
   position: fixed;
-  top: 2rem;
+  top: 1rem;
   width: 100%;
   max-width: 88rem;
+  right: 50%;
+  transform: translate(50%);
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: center;
+  justify-content: center;
   z-index: 1;
 
   @media ${deviceBreakpoints.m} {
@@ -62,7 +74,7 @@ const Wrapper = styled.div`
   }
 `;
 
-const Alert = styled.div`
+const Alert = styled.div<{ animationDuration: number }>`
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -74,7 +86,7 @@ const Alert = styled.div`
   padding: 1.6rem;
   visibility: hidden;
   opacity: 0;
-  animation: fadeinout 3s;
+  animation: fadeinout ${({ animationDuration }) => animationDuration}s;
   border-bottom: 0.1rem solid white;
 
   @keyframes fadeinout {

--- a/src/components/alert-message/alert-messages.tsx
+++ b/src/components/alert-message/alert-messages.tsx
@@ -1,4 +1,4 @@
-import { AlertMessage } from "@fwl/web";
+import { AlertMessage as AlertMessageDataStructure } from "@fwl/web";
 import React from "react";
 import styled from "styled-components";
 
@@ -6,12 +6,8 @@ import { CrossIcon } from "../icons/cross-icon/cross-icon";
 import { deviceBreakpoints } from "@src/design-system/theme";
 
 const AlertMessages: React.FC<{
-  alertMessages?: AlertMessage[];
+  alertMessages?: AlertMessageDataStructure[];
 }> = ({ alertMessages }) => {
-  const [showAlertMessages, setShowAlertMessages] = React.useState<boolean>(
-    true,
-  );
-
   if (!alertMessages) {
     return null;
   }
@@ -21,26 +17,31 @@ const AlertMessages: React.FC<{
 
   return (
     <Wrapper>
-      {showAlertMessages
-        ? alertMessages.map(({ text, expiresAt }) => {
-            if (expiresAt < Date.now()) {
-              return null;
-            }
+      {alertMessages.map(({ text, expiresAt }) => {
+        if (expiresAt < Date.now()) {
+          return null;
+        }
 
-            return (
-              <Alert key={"alertMessage" + Date.now()}>
-                <p>{text}</p>
-                <div
-                  className="cross"
-                  onClick={() => setShowAlertMessages(false)}
-                >
-                  <CrossIcon />
-                </div>
-              </Alert>
-            );
-          })
-        : null}
+        return <AlertMessage key={"alertMessage" + Date.now()} text={text} />;
+      })}
     </Wrapper>
+  );
+};
+
+const AlertMessage: React.FC<{ text: string }> = ({ text }) => {
+  const [showAlertMessage, setShowAlertMessage] = React.useState<boolean>(true);
+
+  if (!showAlertMessage) {
+    return null;
+  }
+
+  return (
+    <Alert>
+      <p>{text}</p>
+      <div className="cross" onClick={() => setShowAlertMessage(false)}>
+        <CrossIcon />
+      </div>
+    </Alert>
   );
 };
 

--- a/src/components/dev-buttons/dev-buttons.tsx
+++ b/src/components/dev-buttons/dev-buttons.tsx
@@ -2,11 +2,14 @@ import React from "react";
 import styled from "styled-components";
 
 const DevButtonAddAlertMessage: React.FC = () => {
-  const count = 0;
   const cookiesList = encodeURIComponent(
     JSON.stringify([
       {
-        text: `This is the alert message number ${count}`,
+        text: `This is an alert message`,
+        expiresAt: Date.now() + 300000,
+      },
+      {
+        text: `This is an alert message`,
         expiresAt: Date.now() + 300000,
       },
     ]),

--- a/src/components/page-layout.tsx
+++ b/src/components/page-layout.tsx
@@ -1,8 +1,6 @@
-import { AlertMessage } from "@fwl/web";
 import React from "react";
 import styled from "styled-components";
 
-import { AlertMessages } from "./alert-message/alert-messages";
 import { Header } from "./header/header";
 import { DesktopNavigationBar } from "./navigation-bars/desktop-navigation-bar";
 import { MobileNavigationBar } from "./navigation-bars/mobile-navigation-bar";
@@ -10,19 +8,11 @@ import { NavigationBreadcrumbs } from "./navigation-breadcrumbs/navigation-bread
 import { deviceBreakpoints } from "@src/design-system/theme";
 
 const Layout: React.FC<{
-  alertMessages?: AlertMessage[];
   title?: string;
   breadcrumbs?: string[];
-}> = ({ children, alertMessages, title, breadcrumbs }) => {
-  React.useEffect(() => {
-    if (alertMessages) {
-      document.cookie = "alert-messages=; max-age=0; path=/;";
-    }
-  }, []);
-
+}> = ({ children, title, breadcrumbs }) => {
   return (
     <Main>
-      <AlertMessages alertMessages={alertMessages} />
       <MobileDisplayOnly>
         <Header />
         <MobileNavigationBar />

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,9 +1,10 @@
-import { SSRProvider } from "@react-aria/ssr";
+import { AlertMessage } from "@fwl/web";
 import { AppProps } from "next/app";
 import Head from "next/head";
 import React from "react";
 import { ThemeProvider } from "styled-components";
 
+import { AlertMessages } from "@src/components/alert-message/alert-messages";
 import { GlobalStyle } from "@src/design-system/globals/global-style";
 import { theme } from "@src/design-system/theme";
 import "@src/utils/sentry";
@@ -17,20 +18,33 @@ const App: React.FC<AppProps> = ({ Component, pageProps }) => {
 };
 
 const AccountApp: React.FC = ({ children }) => {
+  const [alertMessages, setAlertMessages] = React.useState<AlertMessage[]>([]);
+
+  React.useEffect(() => {
+    const intervalId = setInterval(() => {
+      if (document.cookie) {
+        setAlertMessages([
+          ...alertMessages,
+          ...JSON.parse(decodeURIComponent(document.cookie).split("=")[1]),
+        ]);
+
+        document.cookie = "alert-messages=; max-age=0; path=/;";
+      }
+    }, 1000);
+
+    return () => clearInterval(intervalId);
+  }, []);
+
   return (
-    <SSRProvider>
-      <ThemeProvider theme={theme}>
-        <Head>
-          <meta
-            name="viewport"
-            content="initial-scale=1.0, width=device-width"
-          />
-          <title>Connect Account</title>
-        </Head>
-        <GlobalStyle />
-        {children}
-      </ThemeProvider>
-    </SSRProvider>
+    <ThemeProvider theme={theme}>
+      <Head>
+        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+        <title>Connect Account</title>
+      </Head>
+      <GlobalStyle />
+      <AlertMessages alertMessages={alertMessages} />
+      {children}
+    </ThemeProvider>
   );
 };
 

--- a/src/pages/account/logins/[type]/validation/[eventId].tsx
+++ b/src/pages/account/logins/[type]/validation/[eventId].tsx
@@ -1,5 +1,5 @@
 import { IdentityTypes } from "@fewlines/connect-management";
-import { AlertMessage, getServerSideCookies, HttpStatus } from "@fwl/web";
+import { AlertMessage, HttpStatus } from "@fwl/web";
 import {
   loggingMiddleware,
   tracingMiddleware,
@@ -24,10 +24,9 @@ const ValidateIdentityPage: React.FC<{
   type: IdentityTypes;
   eventId: string;
   alertMessages?: AlertMessage[];
-}> = ({ type, eventId, alertMessages }) => {
+}> = ({ type, eventId }) => {
   return (
     <Layout
-      alertMessages={alertMessages}
       title="Logins"
       breadcrumbs={[
         type.toUpperCase() === IdentityTypes.EMAIL
@@ -69,24 +68,6 @@ const getServerSideProps: GetServerSideProps = async (context) => {
         response.statusCode = HttpStatus.NOT_FOUND;
         response.end();
         return;
-      }
-
-      const alertMessages = await getServerSideCookies<string | undefined>(
-        request,
-        {
-          cookieName: "alert-messages",
-          isCookieSealed: false,
-        },
-      );
-
-      if (alertMessages) {
-        return {
-          props: {
-            type: context.params.type,
-            eventId: context.params.eventId,
-            alertMessages,
-          },
-        };
       }
 
       return {

--- a/src/pages/account/logins/index.tsx
+++ b/src/pages/account/logins/index.tsx
@@ -31,10 +31,9 @@ import { ERRORS_DATA, webErrorFactory } from "@src/web-errors";
 const LoginsOverviewPage: React.FC<{
   sortedIdentities: SortedIdentities;
   alertMessages?: AlertMessage[];
-}> = ({ sortedIdentities, alertMessages }) => {
+}> = ({ sortedIdentities }) => {
   return (
     <Layout
-      alertMessages={alertMessages}
       title="Logins"
       breadcrumbs={["Your emails, phones and social logins"]}
     >
@@ -100,20 +99,6 @@ const getServerSideProps: GetServerSideProps = async (context) => {
 
             throw error;
           });
-
-        const alertMessages = await getServerSideCookies(request, {
-          cookieName: "alert-messages",
-          isCookieSealed: false,
-        });
-
-        if (alertMessages) {
-          return {
-            props: {
-              sortedIdentities,
-              alertMessages,
-            },
-          };
-        }
 
         return {
           props: {


### PR DESCRIPTION
## Description

This PR aims at migrating the alert messages' logic inside `_app.tsx`. I've also refacto each alert messages as a component, with its own state to handle closure/ejection from the DOM.

Fixed:
- Cross icon now close only relevant alert message.
- The alert message wrapper now takes only the width of the alert messages.
- The alert message is now properly ejected from the DOM after animation's end.
- Alert messages key.

## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [ ] **Chore** (non-breaking change which refactors / improves the existing code base).
- [x] **Bug fix** (non-breaking change which fixes an issue).
- [x] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
