### PR TITLE
Prevent e2e tests from throwing undefined `type` error

### DIFF
--- a/src/utils/get-identity-type.ts
+++ b/src/utils/get-identity-type.ts
@@ -3,6 +3,8 @@ import { IdentityTypes } from "@fewlines/connect-management";
 import { UnhandledIdentityType } from "@src/errors/errors";
 
 function getIdentityType(type: string): IdentityTypes {
+  // This check is due to Next's internals causing issue with params when navigating directly to an url.
+  // It will be removed when issue will be fixed.
   if (typeof type !== "string") {
     throw new UnhandledIdentityType(`Can't deal with identity type ${type}`);
   }

--- a/tests/e2e/fill-incorrect-identity-input-values.test.ts
+++ b/tests/e2e/fill-incorrect-identity-input-values.test.ts
@@ -8,10 +8,12 @@ import {
   textBox,
   write,
   into,
+  link,
+  above,
 } from "taiko";
 
 import { authenticateToConnect } from "./utils/authenticate-to-connect";
-// import { configVariables } from "@src/configs/config-variables";
+import { configVariables } from "@src/configs/config-variables";
 
 describe("Account Web Application add identity", () => {
   jest.setTimeout(60000);
@@ -24,7 +26,7 @@ describe("Account Web Application add identity", () => {
         "--start-maximized",
         "--disable-dev-shm",
       ],
-      headless: false,
+      headless: true,
     });
   });
 
@@ -51,26 +53,25 @@ describe("Account Web Application add identity", () => {
       await waitFor("Identity input can't be blank");
       expect(await text("Identity input can't be blank").exists()).toBeTruthy();
 
-      // await focus(textBox({ placeholder: "Enter your email" }));
-      // await write(
-      //   process.env.CONNECT_TEST_ACCOUNT_EMAIL ||
-      //     configVariables.connectTestAccountEmail,
-      // );
-      // await click("Add email");
-      // await waitFor("Something went wrong");
-      // expect(await text("Something went wrong").exists()).toBeTruthy();
-
-      // const baseUrl =
-      //   process.env.CONNECT_TEST_ACCOUNT_URL ||
-      //   configVariables.connectAccountURL + "/";
-
-      // await goto(`${baseUrl}account/logins/phone/new`);
+      await write(
+        process.env.CONNECT_TEST_ACCOUNT_EMAIL ||
+          configVariables.connectTestAccountEmail,
+        into(textBox({ placeholder: "Enter your email" })),
+      );
+      await click("Add email");
+      await waitFor("Something went wrong");
+      expect(await text("Something went wrong").exists()).toBeTruthy();
 
       await click("LOGINS");
       await click("+ Add new phone number");
 
       await waitFor("Phone number *");
       expect(await text("Phone number *").exists()).toBeTruthy();
+
+      await click("Add phone");
+      await waitFor("Something went wrong");
+      expect(await text("Something went wrong").exists()).toBeTruthy();
+
       await write(
         "000000000000000000000000000000",
         into(textBox({ placeholder: "Enter your phone number" })),
@@ -100,11 +101,36 @@ describe("Account Web Application add identity", () => {
       expect(await text("LOGINS").exists()).toBeTruthy();
       await click("LOGINS");
 
+      await click("Show");
+      expect(await text("Hide").exists()).toBeTruthy();
+      const nonPrimaryYet = await link(".test", above("Hide")).text();
+      await click(nonPrimaryYet);
+
+      expect(await text("Update this email address").exists()).toBeTruthy();
+      await click("Update this email address");
+
+      await waitFor("New email address *");
+
+      await click("Update email");
+      await waitFor("Identity input can't be blank");
+      expect(await text("Identity input can't be blank").exists()).toBeTruthy();
+
+      await write(
+        nonPrimaryYet,
+        into(textBox({ placeholder: "Enter your email" })),
+      );
+
+      expect(await text("Update email").exists()).toBeTruthy();
+      await click("Update email");
+
+      await waitFor("Something went wrong");
+      expect(await text("Something went wrong").exists()).toBeTruthy();
+
       done();
     } catch (error) {
       await screenshot({
         path:
-          "tests/e2e/screenshots/fill-incorrect-add-identity-input-values.test.png",
+          "tests/e2e/screenshots/fill-incorrect-update-identity-input-values.test.png",
       });
 
       done(error);

--- a/tests/e2e/fill-incorrect-identity-input-values.test.ts
+++ b/tests/e2e/fill-incorrect-identity-input-values.test.ts
@@ -1,18 +1,17 @@
 import {
   openBrowser,
   closeBrowser,
-  goto,
   text,
   click,
   screenshot,
   waitFor,
   textBox,
-  focus,
   write,
+  into,
 } from "taiko";
 
 import { authenticateToConnect } from "./utils/authenticate-to-connect";
-import { configVariables } from "@src/configs/config-variables";
+// import { configVariables } from "@src/configs/config-variables";
 
 describe("Account Web Application add identity", () => {
   jest.setTimeout(60000);
@@ -25,7 +24,7 @@ describe("Account Web Application add identity", () => {
         "--start-maximized",
         "--disable-dev-shm",
       ],
-      headless: true,
+      headless: false,
     });
   });
 
@@ -33,7 +32,7 @@ describe("Account Web Application add identity", () => {
     await closeBrowser();
   });
 
-  test("It should show error messages if Identity inputs are filled incorrectly", async (done) => {
+  test("It should show error messages if Identity inputs are filled incorrectly in add identity", async (done) => {
     expect.assertions(8);
 
     try {
@@ -52,16 +51,30 @@ describe("Account Web Application add identity", () => {
       await waitFor("Identity input can't be blank");
       expect(await text("Identity input can't be blank").exists()).toBeTruthy();
 
-      const baseUrl =
-        process.env.CONNECT_TEST_ACCOUNT_URL ||
-        configVariables.connectAccountURL + "/";
+      // await focus(textBox({ placeholder: "Enter your email" }));
+      // await write(
+      //   process.env.CONNECT_TEST_ACCOUNT_EMAIL ||
+      //     configVariables.connectTestAccountEmail,
+      // );
+      // await click("Add email");
+      // await waitFor("Something went wrong");
+      // expect(await text("Something went wrong").exists()).toBeTruthy();
 
-      await goto(`${baseUrl}account/logins/phone/new`);
+      // const baseUrl =
+      //   process.env.CONNECT_TEST_ACCOUNT_URL ||
+      //   configVariables.connectAccountURL + "/";
+
+      // await goto(`${baseUrl}account/logins/phone/new`);
+
+      await click("LOGINS");
+      await click("+ Add new phone number");
 
       await waitFor("Phone number *");
       expect(await text("Phone number *").exists()).toBeTruthy();
-      await focus(textBox({ placeholder: "Enter your phone number" }));
-      await write("000000000000000000000000000000");
+      await write(
+        "000000000000000000000000000000",
+        into(textBox({ placeholder: "Enter your phone number" })),
+      );
       await click("Add phone");
       await waitFor("Invalid phone number format input.");
       expect(
@@ -72,7 +85,26 @@ describe("Account Web Application add identity", () => {
     } catch (error) {
       await screenshot({
         path:
-          "tests/e2e/screenshots/fill-incorrect-identity-input-values.test.png",
+          "tests/e2e/screenshots/fill-incorrect-add-identity-input-values.test.png",
+      });
+
+      done(error);
+    }
+  });
+
+  test("It should show error messages if Identity inputs are filled incorrectly in update identity", async (done) => {
+    expect.assertions(8);
+
+    try {
+      await waitFor("LOGINS");
+      expect(await text("LOGINS").exists()).toBeTruthy();
+      await click("LOGINS");
+
+      done();
+    } catch (error) {
+      await screenshot({
+        path:
+          "tests/e2e/screenshots/fill-incorrect-add-identity-input-values.test.png",
       });
 
       done(error);

--- a/tests/e2e/fill-incorrect-identity-input-values.test.ts
+++ b/tests/e2e/fill-incorrect-identity-input-values.test.ts
@@ -35,7 +35,7 @@ describe("Account Web Application add identity", () => {
   });
 
   test("It should show error messages if Identity inputs are filled incorrectly in add identity", async (done) => {
-    expect.assertions(8);
+    expect.assertions(10);
 
     try {
       await authenticateToConnect();
@@ -69,8 +69,8 @@ describe("Account Web Application add identity", () => {
       expect(await text("Phone number *").exists()).toBeTruthy();
 
       await click("Add phone");
-      await waitFor("Something went wrong");
-      expect(await text("Something went wrong").exists()).toBeTruthy();
+      await waitFor("Identity input can't be blank");
+      expect(await text("Identity input can't be blank").exists()).toBeTruthy();
 
       await write(
         "000000000000000000000000000000",
@@ -94,7 +94,7 @@ describe("Account Web Application add identity", () => {
   });
 
   test("It should show error messages if Identity inputs are filled incorrectly in update identity", async (done) => {
-    expect.assertions(8);
+    expect.assertions(6);
 
     try {
       await waitFor("LOGINS");


### PR DESCRIPTION
## Description

<!--- Include a summary of the changes, which issue is fixed and, relevant motivation and context -->
This PR change the way we navigate in the `fill-incorrect-identity-input-values.test.ts` from adding an email and adding a phone. Since lastest Next's version bump, we sometimes have issue with direct navigation by typing an url in the browser. So, to minimize errors occurence until the issue is fixed, I replaced this kind of navigation that we were using in this test file, to navigate with app's links instead. 

I took the occasion to improve a little bit the things we are testing by adding tests for the update identity form. Since our test user doesn't have phone numbers now, I couldn't had tests for update phone number identity for now, we should do it later.

## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [ ] **Chore** (non-breaking change which refactors / improves the existing code base).
- [x] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
