### PR TITLE
Refacto breadcrumbs to display skeleton component

### DIFF
--- a/src/components/navigation-breadcrumbs/navigation-breadcrumbs.stories.tsx
+++ b/src/components/navigation-breadcrumbs/navigation-breadcrumbs.stories.tsx
@@ -3,11 +3,11 @@ import React from "react";
 import { NavigationBreadcrumbs } from "./navigation-breadcrumbs";
 
 const OneLevelNavigationBreadcrumbs = (): JSX.Element => {
-  return <NavigationBreadcrumbs breadcrumbs={"Phone number"} />;
+  return <NavigationBreadcrumbs breadcrumbs="Phone number" />;
 };
 
 const TwoLevelsNavigationBreadcrumbs = (): JSX.Element => {
-  return <NavigationBreadcrumbs breadcrumbs={"Phone number | validation"} />;
+  return <NavigationBreadcrumbs breadcrumbs="Phone number | validation" />;
 };
 
 export { OneLevelNavigationBreadcrumbs, TwoLevelsNavigationBreadcrumbs };

--- a/src/components/navigation-breadcrumbs/navigation-breadcrumbs.tsx
+++ b/src/components/navigation-breadcrumbs/navigation-breadcrumbs.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { SkeletonTextLine } from "../skeletons/skeletons";
 
 const NavigationBreadcrumbs: React.FC<{
-  breadcrumbs: string | boolean;
+  breadcrumbs: string | false;
 }> = ({ breadcrumbs }) => {
   if (breadcrumbs === "") {
     return (

--- a/src/components/navigation-breadcrumbs/navigation-breadcrumbs.tsx
+++ b/src/components/navigation-breadcrumbs/navigation-breadcrumbs.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { SkeletonTextLine } from "../skeletons/skeletons";
 
 const NavigationBreadcrumbs: React.FC<{
-  breadcrumbs: string;
+  breadcrumbs: string | boolean;
 }> = ({ breadcrumbs }) => {
   if (breadcrumbs === "") {
     return (
@@ -11,6 +11,10 @@ const NavigationBreadcrumbs: React.FC<{
         <SkeletonTextLine fontSize={1.4} />
       </h3>
     );
+  }
+
+  if (!breadcrumbs) {
+    return null;
   }
 
   return <h3>{breadcrumbs}</h3>;

--- a/src/components/page-layout.tsx
+++ b/src/components/page-layout.tsx
@@ -8,7 +8,7 @@ import { NavigationBreadcrumbs } from "./navigation-breadcrumbs/navigation-bread
 import { deviceBreakpoints } from "@src/design-system/theme";
 
 const Layout: React.FC<{
-  breadcrumbs: string | boolean;
+  breadcrumbs: string | false;
   title?: string;
 }> = ({ children, title, breadcrumbs }) => {
   return (
@@ -71,7 +71,7 @@ const DesktopNavigationBarWrapper = styled.div`
 `;
 
 const ChildrenContainer = styled.div<{
-  breadcrumbs: string | boolean;
+  breadcrumbs: string | false;
   titleText?: string;
 }>`
   width: 60%;

--- a/src/components/page-layout.tsx
+++ b/src/components/page-layout.tsx
@@ -8,8 +8,8 @@ import { NavigationBreadcrumbs } from "./navigation-breadcrumbs/navigation-bread
 import { deviceBreakpoints } from "@src/design-system/theme";
 
 const Layout: React.FC<{
+  breadcrumbs: string | boolean;
   title?: string;
-  breadcrumbs?: string;
 }> = ({ children, title, breadcrumbs }) => {
   return (
     <Main>
@@ -23,13 +23,13 @@ const Layout: React.FC<{
         </DesktopNavigationBarWrapper>
         <ChildrenContainer titleText={title} breadcrumbs={breadcrumbs}>
           {title ? (
-            <MainTitle needSpacing={breadcrumbs ? false : true}>
+            <MainTitle
+              needSpacing={breadcrumbs || breadcrumbs === "" ? false : true}
+            >
               {title}
             </MainTitle>
           ) : null}
-          {breadcrumbs ? (
-            <NavigationBreadcrumbs breadcrumbs={breadcrumbs} />
-          ) : null}
+          <NavigationBreadcrumbs breadcrumbs={breadcrumbs} />
           {children}
         </ChildrenContainer>
       </Flex>
@@ -71,8 +71,8 @@ const DesktopNavigationBarWrapper = styled.div`
 `;
 
 const ChildrenContainer = styled.div<{
+  breadcrumbs: string | boolean;
   titleText?: string;
-  breadcrumbs?: string;
 }>`
   width: 60%;
   margin: 0 auto;

--- a/src/components/pages/identity-overview/identity-overview.tsx
+++ b/src/components/pages/identity-overview/identity-overview.tsx
@@ -90,8 +90,11 @@ const IdentityOverview: React.FC<{
                 setConfirmationBoxOpen(true);
               }}
             >
-              Make {data.identity.value} my primary{" "}
-              {data.identity.type.toLowerCase()}
+              Make this{" "}
+              {getIdentityType(data.identity.type) === IdentityTypes.EMAIL
+                ? "email address"
+                : "phone number"}{" "}
+              my primary one
             </Button>
           )}
           {!data.identity.primary && (

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -28,7 +28,7 @@ const CustomErrorComponent = (
   }
 
   return (
-    <Layout>
+    <Layout breadcrumbs={false}>
       <ErrorFallbackComponent statusCode={statusCode} />
     </Layout>
   );

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -19,7 +19,7 @@ import { sentryMiddleware } from "@src/middlewares/sentry-middleware";
 
 const AccountPage: React.FC = () => {
   return (
-    <Layout title="Welcome to your account">
+    <Layout breadcrumbs={false} title="Welcome to your account">
       <Container>
         <AccountOverview />
       </Container>

--- a/src/pages/account/locale.tsx
+++ b/src/pages/account/locale.tsx
@@ -19,7 +19,7 @@ import { sentryMiddleware } from "@src/middlewares/sentry-middleware";
 
 const LocalePage: React.FC = () => {
   return (
-    <Layout title="Switch Language">
+    <Layout breadcrumbs={false} title="Switch Language">
       <Container>
         <Locale />
       </Container>

--- a/src/pages/account/logins/[type]/[id]/index.tsx
+++ b/src/pages/account/logins/[type]/[id]/index.tsx
@@ -39,7 +39,7 @@ const IdentityOverviewPage: React.FC<{
     : "";
 
   return (
-    <Layout title="Logins" breadcrumbs={breadcrumbs}>
+    <Layout breadcrumbs={breadcrumbs} title="Logins">
       <Container>
         <IdentityOverview data={data} />
       </Container>

--- a/src/pages/account/logins/[type]/[id]/update.tsx
+++ b/src/pages/account/logins/[type]/[id]/update.tsx
@@ -37,7 +37,7 @@ const UpdateIdentityPage: React.FC<{ identityId: string }> = ({
     : "";
 
   return (
-    <Layout title="Logins" breadcrumbs={breadcrumbs}>
+    <Layout breadcrumbs={breadcrumbs} title="Logins">
       <Container>
         <UpdateIdentityForm data={data} />
       </Container>

--- a/src/pages/account/logins/[type]/new.tsx
+++ b/src/pages/account/logins/[type]/new.tsx
@@ -22,12 +22,12 @@ import { getIdentityType } from "@src/utils/get-identity-type";
 const AddIdentityPage: React.FC<{ type: IdentityTypes }> = ({ type }) => {
   return (
     <Layout
-      title="Logins"
       breadcrumbs={`${
         getIdentityType(type) === IdentityTypes.EMAIL
           ? "Email address"
           : "Phone number"
       } | new`}
+      title="Logins"
     >
       <Container>
         <AddIdentityForm type={type} />

--- a/src/pages/account/logins/[type]/validation/[eventId].tsx
+++ b/src/pages/account/logins/[type]/validation/[eventId].tsx
@@ -27,12 +27,12 @@ const ValidateIdentityPage: React.FC<{
 }> = ({ type, eventId }) => {
   return (
     <Layout
-      title="Logins"
       breadcrumbs={`${
         getIdentityType(type) === IdentityTypes.EMAIL
           ? "Email address"
           : "Phone number"
       } | validation`}
+      title="Logins"
     >
       <Container>
         <ValidateIdentityForm type={type} eventId={eventId} />

--- a/src/pages/account/logins/index.tsx
+++ b/src/pages/account/logins/index.tsx
@@ -19,10 +19,7 @@ import { sentryMiddleware } from "@src/middlewares/sentry-middleware";
 
 const LoginsOverviewPage: React.FC = () => {
   return (
-    <Layout
-      title="Logins"
-      breadcrumbs={"Your emails, phones and social logins"}
-    >
+    <Layout breadcrumbs="Your emails, phones and social logins" title="Logins">
       <Container>
         <LoginsOverview />
       </Container>

--- a/src/pages/account/security/index.tsx
+++ b/src/pages/account/security/index.tsx
@@ -19,7 +19,7 @@ import { sentryMiddleware } from "@src/middlewares/sentry-middleware";
 
 const SecurityPage: React.FC = () => {
   return (
-    <Layout title="Security" breadcrumbs={"Password, login history and more"}>
+    <Layout breadcrumbs="Password, login history and more" title="Security">
       <Container>
         <Security />
       </Container>

--- a/src/pages/account/security/sudo.tsx
+++ b/src/pages/account/security/sudo.tsx
@@ -19,7 +19,7 @@ import { sentryMiddleware } from "@src/middlewares/sentry-middleware";
 
 const SudoPage: React.FC = () => {
   return (
-    <Layout title="Security">
+    <Layout breadcrumbs={false} title="Security">
       <Container>
         <TwoFA />
       </Container>

--- a/src/pages/account/security/update.tsx
+++ b/src/pages/account/security/update.tsx
@@ -45,7 +45,7 @@ const SecurityUpdatePage: React.FC = () => {
   }
 
   return (
-    <Layout title="Security" breadcrumbs={conditionalBreadcrumb}>
+    <Layout breadcrumbs={conditionalBreadcrumb} title="Security">
       <Container>
         <SetPasswordForm
           conditionalBreadcrumbItem={

--- a/tests/pages/identity-overview-page.test.tsx
+++ b/tests/pages/identity-overview-page.test.tsx
@@ -1,4 +1,3 @@
-import { Identity } from "@fewlines/connect-management";
 import React from "react";
 import { cache, SWRConfig } from "swr";
 
@@ -15,13 +14,6 @@ jest.mock("@src/configs/db-client", () => {
     },
   };
 });
-
-function makeAsPrimaryRegExFactory(identity: Identity): RegExp {
-  return new RegExp(
-    "Make " + identity.value + " my primary " + identity.type.toLowerCase(),
-    "i",
-  );
-}
 
 describe("IdentityOverviewPage", () => {
   afterEach(() => {
@@ -73,9 +65,7 @@ describe("IdentityOverviewPage", () => {
 
       expect(
         await screen.findByRole("button", {
-          name: makeAsPrimaryRegExFactory(
-            mockIdentities.nonPrimaryEmailIdentity,
-          ),
+          name: /Make this email address my primary one/i,
         }),
       ).toBeInTheDocument();
       expect(
@@ -138,9 +128,7 @@ describe("IdentityOverviewPage", () => {
       await waitFor(() => {
         expect(
           screen.queryByRole("button", {
-            name: makeAsPrimaryRegExFactory(
-              mockIdentities.primaryEmailIdentity,
-            ),
+            name: /Make this email address my primary one/i,
           }),
         ).not.toBeInTheDocument();
         expect(
@@ -196,9 +184,7 @@ describe("IdentityOverviewPage", () => {
 
       expect(
         screen.queryByRole("button", {
-          name: makeAsPrimaryRegExFactory(
-            mockIdentities.unvalidatedEmailIdentity,
-          ),
+          name: /Make this email address my primary one/i,
         }),
       ).not.toBeInTheDocument();
       expect(
@@ -280,9 +266,7 @@ describe("IdentityOverviewPage", () => {
 
       expect(
         await screen.findByRole("button", {
-          name: makeAsPrimaryRegExFactory(
-            mockIdentities.nonPrimaryPhoneIdentity,
-          ),
+          name: /Make this phone number my primary one/i,
         }),
       ).toBeInTheDocument();
       expect(
@@ -345,9 +329,7 @@ describe("IdentityOverviewPage", () => {
       await waitFor(() => {
         expect(
           screen.queryByRole("button", {
-            name: makeAsPrimaryRegExFactory(
-              mockIdentities.primaryPhoneIdentity,
-            ),
+            name: /Make this phone number my primary one/i,
           }),
         ).not.toBeInTheDocument();
         expect(
@@ -413,9 +395,7 @@ describe("IdentityOverviewPage", () => {
       ).toBeInTheDocument();
       expect(
         screen.queryByRole("button", {
-          name: makeAsPrimaryRegExFactory(
-            mockIdentities.unvalidatedPhoneIdentity,
-          ),
+          name: /Make this phone number my primary one/i,
         }),
       ).not.toBeInTheDocument();
     });

--- a/tests/unit/confirmation-box.test.tsx
+++ b/tests/unit/confirmation-box.test.tsx
@@ -1,4 +1,3 @@
-import { Identity } from "@fewlines/connect-management";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { cache, SWRConfig } from "swr";
@@ -6,12 +5,6 @@ import { cache, SWRConfig } from "swr";
 import { render, screen, waitFor } from "../config/testing-library-config";
 import * as mockIdentities from "../mocks/identities";
 import IdentityOverviewPage from "@src/pages/account/logins/[type]/[id]";
-
-function makeAsPrimaryRegExFactory(identity: Identity): RegExp {
-  return new RegExp(
-    "Make " + identity.value + " my primary " + identity.type.toLowerCase(),
-  );
-}
 
 jest.mock("@src/configs/db-client", () => {
   return {
@@ -80,7 +73,7 @@ describe("ConfirmationBox", () => {
 
     userEvent.click(
       await screen.findByRole("button", {
-        name: makeAsPrimaryRegExFactory(mockIdentities.nonPrimaryEmailIdentity),
+        name: /Make this email address my primary one/i,
       }),
     );
 


### PR DESCRIPTION
## Description

<!--- Include a summary of the changes, which issue is fixed and, relevant motivation and context -->

This PR fixes the fact that the skeleton text line component wasn't displayed when waiting for data fetching. 

So now, `breadcrumbs` is no longer an optional argument in `page-layout.tsx`. Its type is either `string` if breadcrumbs should be displayed (empty string when waiting for data fetching), either `boolean` `false` when they should'nt be displayed. 

## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] **Chore** (non-breaking change which refactors / improves the existing code base).
- [ ] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Checklist

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
