### PR TITLE
Adding alert messages after add or update identity flow + fixes

### DIFF
--- a/src/components/forms/verify-two-fa-code-form.tsx
+++ b/src/components/forms/verify-two-fa-code-form.tsx
@@ -106,7 +106,7 @@ const MultipleInputsMasked = styled(InputText)`
   letter-spacing: 4.35rem;
   width: 85%;
   font-size: ${({ theme }) => theme.fontSizes.paragraph};
-  font-family: monospace;
+  font-family: monospace, monospace;
   caret-color: transparent;
   position: relative;
   left: 1.95rem;

--- a/src/components/pages/logins-overview/logins-overview-sections.tsx
+++ b/src/components/pages/logins-overview/logins-overview-sections.tsx
@@ -153,13 +153,13 @@ const IdentityValue = styled.p<Pick<Identity, "primary" | "status">>`
   overflow: hidden;
   text-overflow: ellipsis;
   width: 90%;
+  line-height: ${({ theme }) => theme.lineHeights.copy};
 
   ${(props) =>
     props.primary &&
     `
       font-weight: ${props.theme.fontWeights.semibold};
     `}
-
   ${(props) =>
     props.status === "unvalidated" &&
     `

--- a/src/pages/api/auth-connect/verify-validation-code.ts
+++ b/src/pages/api/auth-connect/verify-validation-code.ts
@@ -6,6 +6,7 @@ import {
   GraphqlErrors,
   addIdentityToUser,
   markIdentityAsPrimary,
+  IdentityTypes,
 } from "@fewlines/connect-management";
 import {
   Endpoint,
@@ -154,10 +155,19 @@ const handler: Handler = async (request, response) => {
             });
           });
 
+          const updateMessage = `${
+            getIdentityType(type) === IdentityTypes.EMAIL
+              ? "Email address"
+              : "Phone number"
+          } has been updated`;
+
+          setAlertMessagesCookie(response, [
+            generateAlertMessage(updateMessage),
+          ]);
+
           response.writeHead(HttpStatus.TEMPORARY_REDIRECT, {
             Location: "/account/logins",
           });
-
           response.end();
           return;
         })
@@ -256,6 +266,14 @@ const handler: Handler = async (request, response) => {
         });
       },
     );
+
+    const addMessage = `${
+      getIdentityType(type) === IdentityTypes.EMAIL
+        ? "New email address"
+        : "New phone number"
+    } has been added`;
+
+    setAlertMessagesCookie(response, [generateAlertMessage(addMessage)]);
 
     response.writeHead(HttpStatus.TEMPORARY_REDIRECT, {
       Location: "/account/logins",


### PR DESCRIPTION
## Description

<!--- Include a summary of the changes, which issue is fixed and, relevant motivation and context -->
This PR adds alert messages after successful add or update identity flow. 

It fixes an issue with the identity display in logins overview, where the bottom of text was cropped due to a too small `line-height` property associated with the recent addition of `overflow: hidden;` on `<p>` too handle too long text without breaking UI. The soluce was to set `line-height` to a bigger value. 

Regarding issue regarding the numbers alignment inside the multiple inputs of sudo page in Chrome and Safari, the fix consisted in adding another "monospace" in this element's `font-family` property. It seems that some browsers tries to resize text declared with Monospace font-family, which seems to cause this display issue on our side. (found here => https://code.iamkate.com/html-and-css/fixing-browsers-broken-monospace-font-handling/).

## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [ ] **Chore** (non-breaking change which refactors / improves the existing code base).
- [ ] **Bug fix** (non-breaking change which fixes an issue).
- [x] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Checklist

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
