### PR TITLE
Use autocomplete one-time-password for OTP + auto focus

### DIFF
--- a/src/components/forms/form.tsx
+++ b/src/components/forms/form.tsx
@@ -3,7 +3,6 @@ import styled from "styled-components";
 
 type FormProps = {
   formID?: string;
-  autoComplete?: string;
   onSubmit: (event?: React.FormEvent<HTMLFormElement>) => Promise<void>;
   children: React.ReactNode | React.ReactNode[];
   className?: string;
@@ -12,7 +11,6 @@ type FormProps = {
 const Form: React.FC<FormProps> = ({
   formID,
   onSubmit,
-  autoComplete,
   children,
   className,
 }) => {
@@ -26,7 +24,6 @@ const Form: React.FC<FormProps> = ({
     <StyledForm
       method="post"
       className={className}
-      autoComplete={autoComplete}
       onSubmit={async (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
 

--- a/src/components/forms/form.tsx
+++ b/src/components/forms/form.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 type FormProps = {
   formID?: string;
+  autoComplete?: string;
   onSubmit: (event?: React.FormEvent<HTMLFormElement>) => Promise<void>;
   children: React.ReactNode | React.ReactNode[];
   className?: string;
@@ -11,6 +12,7 @@ type FormProps = {
 const Form: React.FC<FormProps> = ({
   formID,
   onSubmit,
+  autoComplete,
   children,
   className,
 }) => {
@@ -24,6 +26,7 @@ const Form: React.FC<FormProps> = ({
     <StyledForm
       method="post"
       className={className}
+      autoComplete={autoComplete}
       onSubmit={async (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
 

--- a/src/components/forms/send-two-fa-code-form.tsx
+++ b/src/components/forms/send-two-fa-code-form.tsx
@@ -96,7 +96,6 @@ const SendTwoFACodeForm: React.FC<{
           <span />
         </InputRadioWrapper>
       )}
-
       <Button
         variant={isCodeSent ? ButtonVariant.SECONDARY : ButtonVariant.PRIMARY}
         type="submit"

--- a/src/components/forms/validate-identity-form.tsx
+++ b/src/components/forms/validate-identity-form.tsx
@@ -72,8 +72,11 @@ const ValidateIdentityForm: React.FC<{
         </Box>
         <InputText
           type="text"
-          name="value"
+          inputMode="numeric"
+          name="verification-code"
+          pattern="\d{6}"
           autoComplete="one-time-code"
+          autoFocus={true}
           placeholder="012345"
           value={validationCode}
           onChange={(value) => setValidationCode(value)}

--- a/src/components/forms/validate-identity-form.tsx
+++ b/src/components/forms/validate-identity-form.tsx
@@ -73,6 +73,7 @@ const ValidateIdentityForm: React.FC<{
         <InputText
           type="text"
           name="value"
+          autoComplete="one-time-code"
           placeholder="012345"
           value={validationCode}
           onChange={(value) => setValidationCode(value)}
@@ -83,13 +84,11 @@ const ValidateIdentityForm: React.FC<{
           variant={ButtonVariant.PRIMARY}
         >{`Confirm ${type.toLowerCase()}`}</Button>
       </Form>
-
       <NeutralLink href="/account/logins">
         <FakeButton variant={ButtonVariant.SECONDARY}>
           Discard all changes
         </FakeButton>
       </NeutralLink>
-
       <DidntReceiveCode>Didn&apos;t receive code?</DidntReceiveCode>
       <Button
         type="button"

--- a/src/components/forms/verify-two-fa-code-form.tsx
+++ b/src/components/forms/verify-two-fa-code-form.tsx
@@ -24,7 +24,6 @@ const VerifyTwoFACodeForm: React.FC<{
   return (
     <ExtendedStyledForm
       formID={formID}
-      // autoComplete="on"
       onSubmit={async () => {
         setFormID(uuidv4());
 
@@ -67,9 +66,10 @@ const VerifyTwoFACodeForm: React.FC<{
       <MultipleInputsMasked
         type="text"
         inputMode="numeric"
-        name="verificationCode"
+        name="verification-code"
         autoComplete="one-time-code"
         pattern="\d{6}"
+        autoFocus={true}
         onChange={(value) => setVerificationCode(value)}
         value={verificationCode}
         label="Enter received code here:"

--- a/src/components/forms/verify-two-fa-code-form.tsx
+++ b/src/components/forms/verify-two-fa-code-form.tsx
@@ -63,7 +63,7 @@ const VerifyTwoFACodeForm: React.FC<{
       }}
     >
       {errorMessage ? <WrongInputError>{errorMessage}.</WrongInputError> : null}
-      <MultipleInputsMasked
+      {/* <MultipleInputsMasked
         type="text"
         inputMode="numeric"
         name="verification-code"
@@ -83,8 +83,19 @@ const VerifyTwoFACodeForm: React.FC<{
           <span />
           <span />
         </InputMask>
-      </MultipleInputsMasked>
-
+      </MultipleInputsMasked> */}
+      <input
+        id="otp-text-field"
+        type="text"
+        inputMode="numeric"
+        name="verification-code"
+        autoComplete="one-time-code"
+        pattern="\d{6}"
+        autoFocus={true}
+        onChange={(event) => setVerificationCode(event.target.value)}
+        value={verificationCode}
+        maxLength={6}
+      />
       <Button variant={ButtonVariant.PRIMARY} type="submit">
         Confirm
       </Button>

--- a/src/components/forms/verify-two-fa-code-form.tsx
+++ b/src/components/forms/verify-two-fa-code-form.tsx
@@ -24,6 +24,7 @@ const VerifyTwoFACodeForm: React.FC<{
   return (
     <ExtendedStyledForm
       formID={formID}
+      // autoComplete="on"
       onSubmit={async () => {
         setFormID(uuidv4());
 
@@ -65,7 +66,10 @@ const VerifyTwoFACodeForm: React.FC<{
       {errorMessage ? <WrongInputError>{errorMessage}.</WrongInputError> : null}
       <MultipleInputsMasked
         type="text"
+        inputMode="numeric"
         name="verificationCode"
+        autoComplete="one-time-code"
+        pattern="\d{6}"
         onChange={(value) => setVerificationCode(value)}
         value={verificationCode}
         label="Enter received code here:"

--- a/src/components/input/input-text.tsx
+++ b/src/components/input/input-text.tsx
@@ -7,6 +7,17 @@ type InputTextProps = {
   name: string;
   label: string;
   onChange: (value: string) => void;
+  autoComplete?: string;
+  inputMode?:
+    | "text"
+    | "search"
+    | "none"
+    | "tel"
+    | "url"
+    | "email"
+    | "numeric"
+    | "decimal";
+  pattern?: string;
   value?: string;
   placeholder?: string;
   className?: string;

--- a/src/components/input/input-text.tsx
+++ b/src/components/input/input-text.tsx
@@ -8,6 +8,7 @@ type InputTextProps = {
   label: string;
   onChange: (value: string) => void;
   autoComplete?: string;
+  autoFocus?: boolean;
   inputMode?:
     | "text"
     | "search"


### PR DESCRIPTION
## Description

This PR aims at adding the `autocomplete` HTML attribute in validation code inputs, and also auto-focus those inputs.

## Type of change

- [ ] **Chore** (non-breaking change which refactors / improves the existing code base).
- [ ] **Bug fix** (non-breaking change which fixes an issue).
- [x] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Checklist

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
