### PR TITLE
Refacto profile client init

### DIFF
--- a/src/configs/profile-client.ts
+++ b/src/configs/profile-client.ts
@@ -8,7 +8,16 @@ import { UserCookie } from "@src/@types/user-cookie";
 import { NoUserCookieFoundError } from "@src/errors/errors";
 import { getProfileAndAddressAccessTokens } from "@src/utils/get-profile-and-address-access-tokens";
 
-async function initProfileClient(
+function initProfileClient(accessToken: string): ConnectProfileApi {
+  return new ConnectProfileApi(
+    new Configuration({
+      accessToken,
+      basePath: configVariables.connectProfileUrl,
+    }),
+  );
+}
+
+async function wrappedProfileClient(
   request: NextApiRequest,
   span: Span,
 ): Promise<{
@@ -30,21 +39,10 @@ async function initProfileClient(
 
   span.setDisclosedAttribute("is Connect.Profile access token available", true);
 
-  const userProfileClient = new ConnectProfileApi(
-    new Configuration({
-      accessToken: profileAccessToken,
-      basePath: configVariables.connectProfileUrl,
-    }),
-  );
-
-  const userAddressClient = new ConnectProfileApi(
-    new Configuration({
-      accessToken: addressAccessToken,
-      basePath: configVariables.connectProfileUrl,
-    }),
-  );
-
-  return { userProfileClient, userAddressClient };
+  return {
+    userProfileClient: initProfileClient(profileAccessToken),
+    userAddressClient: initProfileClient(addressAccessToken),
+  };
 }
 
-export { initProfileClient };
+export { initProfileClient, wrappedProfileClient };

--- a/src/configs/profile-client.ts
+++ b/src/configs/profile-client.ts
@@ -1,13 +1,50 @@
+import { Span } from "@fwl/tracing";
+import { getServerSideCookies } from "@fwl/web";
+import { NextApiRequest } from "next";
+
 import { Configuration, ConnectProfileApi } from "../../connect-profile-client";
 import { configVariables } from "./config-variables";
+import { UserCookie } from "@src/@types/user-cookie";
+import { NoUserCookieFoundError } from "@src/errors/errors";
+import { getProfileAndAddressAccessTokens } from "@src/utils/get-profile-and-address-access-tokens";
 
-function initProfileClient(accessToken: string): ConnectProfileApi {
-  return new ConnectProfileApi(
+async function initProfileClient(
+  request: NextApiRequest,
+  span: Span,
+): Promise<{
+  userProfileClient: ConnectProfileApi;
+  userAddressClient: ConnectProfileApi;
+}> {
+  const userCookie = await getServerSideCookies<UserCookie>(request, {
+    cookieName: "user-cookie",
+    isCookieSealed: true,
+    cookieSalt: configVariables.cookieSalt,
+  });
+
+  if (!userCookie) {
+    throw new NoUserCookieFoundError();
+  }
+
+  const { profileAccessToken, addressAccessToken } =
+    await getProfileAndAddressAccessTokens(userCookie.access_token);
+
+  span.setDisclosedAttribute("is Connect.Profile access token available", true);
+
+  const userProfileClient = new ConnectProfileApi(
     new Configuration({
-      accessToken,
+      accessToken: profileAccessToken,
       basePath: configVariables.connectProfileUrl,
     }),
   );
+
+  const userAddressClient = new ConnectProfileApi(
+    new Configuration({
+      accessToken: addressAccessToken,
+      basePath: configVariables.connectProfileUrl,
+    }),
+  );
+
+  return { userProfileClient, userAddressClient };
 }
 
 export { initProfileClient };

--- a/src/pages/api/profile/addresses/[id]/index.ts
+++ b/src/pages/api/profile/addresses/[id]/index.ts
@@ -12,7 +12,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 
 import { Handler } from "@src/@types/handler";
 import { logger } from "@src/configs/logger";
-import { initProfileClient } from "@src/configs/profile-client";
+import { wrappedProfileClient } from "@src/configs/profile-client";
 import rateLimitingConfig from "@src/configs/rate-limiting-config";
 import getTracer from "@src/configs/tracer";
 import { ERRORS_DATA, webErrorFactory } from "@src/errors/web-errors";
@@ -39,7 +39,7 @@ const getHandler: Handler = async (request, response) => {
         throw webErrorFactory(webErrors.invalidQueryString);
       }
 
-      const { userAddressClient } = await initProfileClient(request, span);
+      const { userAddressClient } = await wrappedProfileClient(request, span);
 
       const { data: profileAddresses } = await userAddressClient
         .getAddresses()
@@ -94,7 +94,7 @@ const patchHandler: Handler = async (request, response) => {
         throw webErrorFactory(webErrors.invalidQueryString);
       }
 
-      const { userAddressClient } = await initProfileClient(request, span);
+      const { userAddressClient } = await wrappedProfileClient(request, span);
 
       const { data: updatedUserAddress } = await userAddressClient
         .updateAddress(addressId, request.body)
@@ -155,7 +155,7 @@ const deleteHandler: Handler = async (request, response) => {
         throw webErrorFactory(webErrors.invalidQueryString);
       }
 
-      const { userAddressClient } = await initProfileClient(request, span);
+      const { userAddressClient } = await wrappedProfileClient(request, span);
 
       await userAddressClient
         .deleteAddress(addressId)

--- a/src/pages/api/profile/addresses/[id]/mark-as-primary.ts
+++ b/src/pages/api/profile/addresses/[id]/mark-as-primary.ts
@@ -12,7 +12,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 
 import { Handler } from "@src/@types/handler";
 import { logger } from "@src/configs/logger";
-import { initProfileClient } from "@src/configs/profile-client";
+import { wrappedProfileClient } from "@src/configs/profile-client";
 import rateLimitingConfig from "@src/configs/rate-limiting-config";
 import getTracer from "@src/configs/tracer";
 import { ERRORS_DATA, webErrorFactory } from "@src/errors/web-errors";
@@ -39,7 +39,7 @@ const markAsPrimaryHandler: Handler = async (request, response) => {
         throw webErrorFactory(webErrors.invalidQueryString);
       }
 
-      const { userAddressClient } = await initProfileClient(request, span);
+      const { userAddressClient } = await wrappedProfileClient(request, span);
 
       const { data: address } = await userAddressClient
         .markUserAddressAsPrimary(addressId)

--- a/src/pages/api/profile/addresses/[id]/mark-as-primary.ts
+++ b/src/pages/api/profile/addresses/[id]/mark-as-primary.ts
@@ -1,9 +1,4 @@
-import {
-  getServerSideCookies,
-  Endpoint,
-  HttpStatus,
-  setAlertMessagesCookie,
-} from "@fwl/web";
+import { Endpoint, HttpStatus, setAlertMessagesCookie } from "@fwl/web";
 import {
   loggingMiddleware,
   wrapMiddlewares,
@@ -16,8 +11,6 @@ import {
 import { NextApiRequest, NextApiResponse } from "next";
 
 import { Handler } from "@src/@types/handler";
-import { UserCookie } from "@src/@types/user-cookie";
-import { configVariables } from "@src/configs/config-variables";
 import { logger } from "@src/configs/logger";
 import { initProfileClient } from "@src/configs/profile-client";
 import rateLimitingConfig from "@src/configs/rate-limiting-config";
@@ -26,7 +19,6 @@ import { ERRORS_DATA, webErrorFactory } from "@src/errors/web-errors";
 import { authMiddleware } from "@src/middlewares/auth-middleware";
 import { sentryMiddleware } from "@src/middlewares/sentry-middleware";
 import { generateAlertMessage } from "@src/utils/generate-alert-message";
-import { getProfileAndAddressAccessTokens } from "@src/utils/get-profile-and-address-access-tokens";
 
 const markAsPrimaryHandler: Handler = async (request, response) => {
   const webErrors = {
@@ -41,36 +33,15 @@ const markAsPrimaryHandler: Handler = async (request, response) => {
   return getTracer().span(
     "POST /api/profile/addresses/[id]/mark-as-primary handler",
     async (span) => {
-      const userCookie = await getServerSideCookies<UserCookie>(request, {
-        cookieName: "user-cookie",
-        isCookieSealed: true,
-        cookieSalt: configVariables.cookieSalt,
-      });
-
-      if (!userCookie) {
-        response.statusCode = HttpStatus.TEMPORARY_REDIRECT;
-        response.setHeader("location", "/");
-        response.end();
-        return;
-      }
-
       const addressId = request.query.id;
 
       if (!addressId || typeof addressId !== "string") {
         throw webErrorFactory(webErrors.invalidQueryString);
       }
 
-      const { addressAccessToken } = await getProfileAndAddressAccessTokens(
-        userCookie.access_token,
-      );
-      span.setDisclosedAttribute(
-        "is Connect.Profile access token available",
-        true,
-      );
+      const { userAddressClient } = await initProfileClient(request, span);
 
-      const addressClient = initProfileClient(addressAccessToken);
-
-      const { data: address } = await addressClient
+      const { data: address } = await userAddressClient
         .markUserAddressAsPrimary(addressId)
         .then((addressData) => {
           setAlertMessagesCookie(response, [

--- a/src/pages/api/profile/addresses/index.ts
+++ b/src/pages/api/profile/addresses/index.ts
@@ -1,9 +1,4 @@
-import {
-  getServerSideCookies,
-  Endpoint,
-  HttpStatus,
-  setAlertMessagesCookie,
-} from "@fwl/web";
+import { Endpoint, HttpStatus, setAlertMessagesCookie } from "@fwl/web";
 import {
   loggingMiddleware,
   wrapMiddlewares,
@@ -16,8 +11,6 @@ import {
 import { NextApiRequest, NextApiResponse } from "next";
 
 import { Handler } from "@src/@types/handler";
-import { UserCookie } from "@src/@types/user-cookie";
-import { configVariables } from "@src/configs/config-variables";
 import { logger } from "@src/configs/logger";
 import { initProfileClient } from "@src/configs/profile-client";
 import rateLimitingConfig from "@src/configs/rate-limiting-config";
@@ -26,7 +19,6 @@ import { ERRORS_DATA, webErrorFactory } from "@src/errors/web-errors";
 import { authMiddleware } from "@src/middlewares/auth-middleware";
 import { sentryMiddleware } from "@src/middlewares/sentry-middleware";
 import { generateAlertMessage } from "@src/utils/generate-alert-message";
-import { getProfileAndAddressAccessTokens } from "@src/utils/get-profile-and-address-access-tokens";
 
 const getHandler: Handler = async (request, response) => {
   const webErrors = {
@@ -39,31 +31,9 @@ const getHandler: Handler = async (request, response) => {
   return getTracer().span(
     "GET /api/profile/addresses handler",
     async (span) => {
-      const userCookie = await getServerSideCookies<UserCookie>(request, {
-        cookieName: "user-cookie",
-        isCookieSealed: true,
-        cookieSalt: configVariables.cookieSalt,
-      });
+      const { userAddressClient } = await initProfileClient(request, span);
 
-      if (!userCookie) {
-        response.statusCode = HttpStatus.TEMPORARY_REDIRECT;
-        response.setHeader("location", "/");
-        response.end();
-        return;
-      }
-
-      const { addressAccessToken } = await getProfileAndAddressAccessTokens(
-        userCookie.access_token,
-      );
-
-      span.setDisclosedAttribute(
-        "is Connect.Profile access token available",
-        true,
-      );
-
-      const addressClient = initProfileClient(addressAccessToken);
-
-      const { data: userAddresses } = await addressClient
+      const { data: userAddresses } = await userAddressClient
         .getAddresses()
         .catch((error) => {
           span.setDisclosedAttribute(
@@ -105,33 +75,10 @@ const postHandler: Handler = async (request, response) => {
   return getTracer().span(
     "POST /api/profile/addresses handler",
     async (span) => {
-      const userCookie = await getServerSideCookies<UserCookie>(request, {
-        cookieName: "user-cookie",
-        isCookieSealed: true,
-        cookieSalt: configVariables.cookieSalt,
-      });
+      const { userAddressClient } = await initProfileClient(request, span);
 
-      if (!userCookie) {
-        response.statusCode = HttpStatus.TEMPORARY_REDIRECT;
-        response.setHeader("location", "/");
-        response.end();
-        return;
-      }
-
-      const userAddressPayload = request.body;
-
-      const { addressAccessToken } = await getProfileAndAddressAccessTokens(
-        userCookie.access_token,
-      );
-      span.setDisclosedAttribute(
-        "is Connect.Profile access token available",
-        true,
-      );
-
-      const addressClient = initProfileClient(addressAccessToken);
-
-      const { data: createdAddress } = await addressClient
-        .createAddress(userAddressPayload)
+      const { data: createdAddress } = await userAddressClient
+        .createAddress(request.body)
         .then((addressData) => {
           setAlertMessagesCookie(response, [
             generateAlertMessage("Your address has been added"),

--- a/src/pages/api/profile/addresses/index.ts
+++ b/src/pages/api/profile/addresses/index.ts
@@ -12,7 +12,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 
 import { Handler } from "@src/@types/handler";
 import { logger } from "@src/configs/logger";
-import { initProfileClient } from "@src/configs/profile-client";
+import { wrappedProfileClient } from "@src/configs/profile-client";
 import rateLimitingConfig from "@src/configs/rate-limiting-config";
 import getTracer from "@src/configs/tracer";
 import { ERRORS_DATA, webErrorFactory } from "@src/errors/web-errors";
@@ -31,7 +31,7 @@ const getHandler: Handler = async (request, response) => {
   return getTracer().span(
     "GET /api/profile/addresses handler",
     async (span) => {
-      const { userAddressClient } = await initProfileClient(request, span);
+      const { userAddressClient } = await wrappedProfileClient(request, span);
 
       const { data: userAddresses } = await userAddressClient
         .getAddresses()
@@ -75,7 +75,7 @@ const postHandler: Handler = async (request, response) => {
   return getTracer().span(
     "POST /api/profile/addresses handler",
     async (span) => {
-      const { userAddressClient } = await initProfileClient(request, span);
+      const { userAddressClient } = await wrappedProfileClient(request, span);
 
       const { data: createdAddress } = await userAddressClient
         .createAddress(request.body)

--- a/src/pages/api/profile/user-profile/index.ts
+++ b/src/pages/api/profile/user-profile/index.ts
@@ -12,7 +12,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 
 import { Handler } from "@src/@types/handler";
 import { logger } from "@src/configs/logger";
-import { initProfileClient } from "@src/configs/profile-client";
+import { wrappedProfileClient } from "@src/configs/profile-client";
 import rateLimitingConfig from "@src/configs/rate-limiting-config";
 import getTracer from "@src/configs/tracer";
 import { ERRORS_DATA, webErrorFactory } from "@src/errors/web-errors";
@@ -31,7 +31,7 @@ const getHandler: Handler = async (request, response) => {
   return getTracer().span(
     "GET /api/profile/user-profile handler",
     async (span) => {
-      const { userProfileClient } = await initProfileClient(request, span);
+      const { userProfileClient } = await wrappedProfileClient(request, span);
 
       const { data: userProfile } = await userProfileClient
         .getProfile()
@@ -79,7 +79,7 @@ const patchHandler: Handler = async (request, response) => {
   return getTracer().span(
     "PATCH /api/profile/user-profile handler",
     async (span) => {
-      const { userProfileClient } = await initProfileClient(request, span);
+      const { userProfileClient } = await wrappedProfileClient(request, span);
 
       const { data: updatedUserProfile } = await userProfileClient
         .patchProfile(request.body)
@@ -137,7 +137,7 @@ const postHandler: Handler = async (request, response) => {
   return getTracer().span(
     "POST /api/profile/user-profile handler",
     async (span) => {
-      const { userProfileClient } = await initProfileClient(request, span);
+      const { userProfileClient } = await wrappedProfileClient(request, span);
 
       const { data: createdUserProfile } = await userProfileClient
         .createProfile(request.body)

--- a/src/pages/api/profile/user-profile/index.ts
+++ b/src/pages/api/profile/user-profile/index.ts
@@ -1,9 +1,4 @@
-import {
-  getServerSideCookies,
-  Endpoint,
-  HttpStatus,
-  setAlertMessagesCookie,
-} from "@fwl/web";
+import { Endpoint, HttpStatus, setAlertMessagesCookie } from "@fwl/web";
 import {
   loggingMiddleware,
   wrapMiddlewares,
@@ -16,8 +11,6 @@ import {
 import { NextApiRequest, NextApiResponse } from "next";
 
 import { Handler } from "@src/@types/handler";
-import { UserCookie } from "@src/@types/user-cookie";
-import { configVariables } from "@src/configs/config-variables";
 import { logger } from "@src/configs/logger";
 import { initProfileClient } from "@src/configs/profile-client";
 import rateLimitingConfig from "@src/configs/rate-limiting-config";
@@ -26,7 +19,6 @@ import { ERRORS_DATA, webErrorFactory } from "@src/errors/web-errors";
 import { authMiddleware } from "@src/middlewares/auth-middleware";
 import { sentryMiddleware } from "@src/middlewares/sentry-middleware";
 import { generateAlertMessage } from "@src/utils/generate-alert-message";
-import { getProfileAndAddressAccessTokens } from "@src/utils/get-profile-and-address-access-tokens";
 
 const getHandler: Handler = async (request, response) => {
   const webErrors = {
@@ -39,31 +31,9 @@ const getHandler: Handler = async (request, response) => {
   return getTracer().span(
     "GET /api/profile/user-profile handler",
     async (span) => {
-      const userCookie = await getServerSideCookies<UserCookie>(request, {
-        cookieName: "user-cookie",
-        isCookieSealed: true,
-        cookieSalt: configVariables.cookieSalt,
-      });
+      const { userProfileClient } = await initProfileClient(request, span);
 
-      if (!userCookie) {
-        response.statusCode = HttpStatus.TEMPORARY_REDIRECT;
-        response.setHeader("location", "/");
-        response.end();
-        return;
-      }
-
-      const { profileAccessToken } = await getProfileAndAddressAccessTokens(
-        userCookie.access_token,
-      );
-
-      span.setDisclosedAttribute(
-        "is Connect.Profile access token available",
-        true,
-      );
-
-      const profileClient = initProfileClient(profileAccessToken);
-
-      const { data: userProfile } = await profileClient
+      const { data: userProfile } = await userProfileClient
         .getProfile()
         .catch((error) => {
           span.setDisclosedAttribute(
@@ -109,33 +79,10 @@ const patchHandler: Handler = async (request, response) => {
   return getTracer().span(
     "PATCH /api/profile/user-profile handler",
     async (span) => {
-      const userCookie = await getServerSideCookies<UserCookie>(request, {
-        cookieName: "user-cookie",
-        isCookieSealed: true,
-        cookieSalt: configVariables.cookieSalt,
-      });
+      const { userProfileClient } = await initProfileClient(request, span);
 
-      if (!userCookie) {
-        response.statusCode = HttpStatus.TEMPORARY_REDIRECT;
-        response.setHeader("location", "/");
-        response.end();
-        return;
-      }
-
-      const { userProfilePayload } = request.body;
-
-      const { profileAccessToken } = await getProfileAndAddressAccessTokens(
-        userCookie.access_token,
-      );
-      span.setDisclosedAttribute(
-        "is Connect.Profile access token available",
-        true,
-      );
-
-      const profileClient = initProfileClient(profileAccessToken);
-
-      const { data: updatedUserProfile } = await profileClient
-        .patchProfile(userProfilePayload)
+      const { data: updatedUserProfile } = await userProfileClient
+        .patchProfile(request.body)
         .then((profileData) => {
           setAlertMessagesCookie(response, [
             generateAlertMessage("Your profile has been updated"),
@@ -190,33 +137,10 @@ const postHandler: Handler = async (request, response) => {
   return getTracer().span(
     "POST /api/profile/user-profile handler",
     async (span) => {
-      const userCookie = await getServerSideCookies<UserCookie>(request, {
-        cookieName: "user-cookie",
-        isCookieSealed: true,
-        cookieSalt: configVariables.cookieSalt,
-      });
+      const { userProfileClient } = await initProfileClient(request, span);
 
-      if (!userCookie) {
-        response.statusCode = HttpStatus.TEMPORARY_REDIRECT;
-        response.setHeader("location", "/");
-        response.end();
-        return;
-      }
-
-      const { userProfilePayload } = request.body;
-
-      const { profileAccessToken } = await getProfileAndAddressAccessTokens(
-        userCookie.access_token,
-      );
-      span.setDisclosedAttribute(
-        "is Connect.Profile access token available",
-        true,
-      );
-
-      const profileClient = initProfileClient(profileAccessToken);
-
-      const { data: createdUserProfile } = await profileClient
-        .createProfile(userProfilePayload)
+      const { data: createdUserProfile } = await userProfileClient
+        .createProfile(request.body)
         .then((profileData) => {
           setAlertMessagesCookie(response, [
             generateAlertMessage("Your profile has been created"),


### PR DESCRIPTION
## Description

This PR aims at refactoring the initialization of the profile clients.

Our intention were to remove a lot of repetitive boilerplate in the code base.

I went with a functional approach to improve the process. I separated it into two functions, which help me with the tests, where we don't care about observability or the check of the `UserCookie`.

This was tested running `Connect.Profile` locally.

## Type of change

- [x] **Chore** (non-breaking change which refactors / improves the existing code base).
- [ ] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Checklist

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
