### PR TITLE
Add store-artifacts steps in e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,8 @@ jobs:
       - run:
           name: Run e2e tests
           command: CONNECT_TEST_ACCOUNT_EMAIL="taiko_${CIRCLE_SHA1}@fewlines.test" yarn test:e2e 
+      - store_artifacts:
+          path: ./tests/e2e/screenshots
       - when: 
           condition: 
             matches: { pattern: ".*?\\bstaging\\b.*?", value: << pipeline.parameters.target_url >> }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint \"{src,pages,bin,doc,tests}/**/*.{js,ts,jsx,tsx}\"",
     "start": "next start -p $PORT",
     "test": "jest --testPathIgnorePatterns=e2e --runInBand",
-    "test:e2e": "jest --testPathPattern=e2e --runInBand -t 'Delete Identity'",
+    "test:e2e": "jest --testPathPattern=e2e --runInBand",
     "test:e2e:local": "ts-node bin/e2e/prepare-e2e-tests.ts && jest --testPathPattern=e2e --runInBand",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint \"{src,pages,bin,doc,tests}/**/*.{js,ts,jsx,tsx}\"",
     "start": "next start -p $PORT",
     "test": "jest --testPathIgnorePatterns=e2e --runInBand",
-    "test:e2e": "jest --testPathPattern=e2e --runInBand",
+    "test:e2e": "jest --testPathPattern=e2e --runInBand -t 'Profile Happy path'",
     "test:e2e:local": "ts-node bin/e2e/prepare-e2e-tests.ts && jest --testPathPattern=e2e --runInBand",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint \"{src,pages,bin,doc,tests}/**/*.{js,ts,jsx,tsx}\"",
     "start": "next start -p $PORT",
     "test": "jest --testPathIgnorePatterns=e2e --runInBand",
-    "test:e2e": "jest --testPathPattern=e2e --runInBand -t 'Profile Happy path'",
+    "test:e2e": "jest --testPathPattern=e2e --runInBand",
     "test:e2e:local": "ts-node bin/e2e/prepare-e2e-tests.ts && jest --testPathPattern=e2e --runInBand",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint \"{src,pages,bin,doc,tests}/**/*.{js,ts,jsx,tsx}\"",
     "start": "next start -p $PORT",
     "test": "jest --testPathIgnorePatterns=e2e --runInBand",
-    "test:e2e": "jest --testPathPattern=e2e --runInBand",
+    "test:e2e": "jest --testPathPattern=e2e --runInBand -t 'Delete Identity'",
     "test:e2e:local": "ts-node bin/e2e/prepare-e2e-tests.ts && jest --testPathPattern=e2e --runInBand",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/tests/e2e/delete-identity.test.ts
+++ b/tests/e2e/delete-identity.test.ts
@@ -46,6 +46,7 @@ describe("Delete Identity", () => {
       await click(text("Delete this email address"));
 
       expect(await text("You are about to delete").exists()).toBeTruthy();
+
       await click("Delete this email address");
 
       expect(

--- a/tests/e2e/delete-identity.test.ts
+++ b/tests/e2e/delete-identity.test.ts
@@ -31,28 +31,23 @@ describe("Delete Identity", () => {
   });
 
   test("It should navigate to the show of the Identity, and delete it", async () => {
-    expect.assertions(13);
+    expect.assertions(7);
 
     try {
       await authenticateToConnect();
 
-      expect(await text("LOGINS").exists()).toBeTruthy();
       await click("LOGINS");
 
-      expect(await text("Show").exists()).toBeTruthy();
       await click("Show");
 
-      expect(await link("_delete_").exists()).toBeTruthy();
       await click(link("_delete_"));
 
-      expect(await text("Delete this email address").exists()).toBeTruthy();
       await click(text("Delete this email address"));
 
       // Waiting to remove SWR cache.
       // await waitFor(2000);
 
       expect(await text("You are about to delete").exists()).toBeTruthy();
-      expect(await text("Delete this email address").exists()).toBeTruthy();
       await click("Delete this email address");
 
       expect(
@@ -62,11 +57,10 @@ describe("Delete Identity", () => {
       // Waiting to remove SWR cache.
       // await waitFor(2000);
 
-      expect(await text("Show").exists()).toBeTruthy();
       await click("Show");
 
       expect(await text("Hide").exists()).toBeTruthy();
-      expect(!(await link("_delete_").exists())).toBeTruthy();
+      expect(await link("_delete_").exists()).toBeFalsy();
     } catch (error) {
       await screenshot({
         path: "./tests/e2e/screenshots/delete-identity.png",

--- a/tests/e2e/delete-identity.test.ts
+++ b/tests/e2e/delete-identity.test.ts
@@ -5,7 +5,6 @@ import {
   click,
   screenshot,
   link,
-  waitFor,
 } from "taiko";
 
 import { authenticateToConnect } from "./utils/authenticate-to-connect";
@@ -22,8 +21,8 @@ describe("Delete Identity", () => {
         "--disable-dev-shm",
       ],
       headless: true,
-      observe: false,
-      observeTime: 2000,
+      observe: true,
+      observeTime: 500,
     });
   });
 
@@ -50,7 +49,7 @@ describe("Delete Identity", () => {
       await click(text("Delete this email address"));
 
       // Waiting to remove SWR cache.
-      await waitFor(2000);
+      // await waitFor(2000);
 
       expect(await text("You are about to delete").exists()).toBeTruthy();
       expect(await text("Delete this email address").exists()).toBeTruthy();
@@ -61,13 +60,12 @@ describe("Delete Identity", () => {
       ).toBeTruthy();
 
       // Waiting to remove SWR cache.
-      await waitFor(2000);
+      // await waitFor(2000);
 
       expect(await text("Show").exists()).toBeTruthy();
       await click("Show");
 
       expect(await text("Hide").exists()).toBeTruthy();
-
       expect(!(await link("_delete_").exists())).toBeTruthy();
     } catch (error) {
       await screenshot({

--- a/tests/e2e/delete-identity.test.ts
+++ b/tests/e2e/delete-identity.test.ts
@@ -42,10 +42,8 @@ describe("Delete Identity", () => {
 
       await click(link("_delete_"));
 
+      expect(await text("Delete this email address").exists()).toBeTruthy();
       await click(text("Delete this email address"));
-
-      // Waiting to remove SWR cache.
-      // await waitFor(2000);
 
       expect(await text("You are about to delete").exists()).toBeTruthy();
       await click("Delete this email address");
@@ -53,9 +51,6 @@ describe("Delete Identity", () => {
       expect(
         await text("Email address has been deleted").exists(),
       ).toBeTruthy();
-
-      // Waiting to remove SWR cache.
-      // await waitFor(2000);
 
       await click("Show");
 

--- a/tests/e2e/delete-identity.test.ts
+++ b/tests/e2e/delete-identity.test.ts
@@ -5,6 +5,7 @@ import {
   click,
   screenshot,
   link,
+  waitFor,
 } from "taiko";
 
 import { authenticateToConnect } from "./utils/authenticate-to-connect";
@@ -21,8 +22,8 @@ describe("Delete Identity", () => {
         "--disable-dev-shm",
       ],
       headless: true,
-      observe: true,
-      observeTime: 500,
+      observe: false,
+      observeTime: 2000,
     });
   });
 
@@ -31,32 +32,43 @@ describe("Delete Identity", () => {
   });
 
   test("It should navigate to the show of the Identity, and delete it", async () => {
-    expect.assertions(7);
+    expect.assertions(13);
 
     try {
       await authenticateToConnect();
 
+      expect(await text("LOGINS").exists()).toBeTruthy();
       await click("LOGINS");
 
+      expect(await text("Show").exists()).toBeTruthy();
       await click("Show");
 
+      expect(await link("_delete_").exists()).toBeTruthy();
       await click(link("_delete_"));
 
       expect(await text("Delete this email address").exists()).toBeTruthy();
       await click(text("Delete this email address"));
 
-      expect(await text("You are about to delete").exists()).toBeTruthy();
+      // Waiting to remove SWR cache.
+      await waitFor(2000);
 
+      expect(await text("You are about to delete").exists()).toBeTruthy();
+      expect(await text("Delete this email address").exists()).toBeTruthy();
       await click("Delete this email address");
 
       expect(
         await text("Email address has been deleted").exists(),
       ).toBeTruthy();
 
+      // Waiting to remove SWR cache.
+      await waitFor(2000);
+
+      expect(await text("Show").exists()).toBeTruthy();
       await click("Show");
 
       expect(await text("Hide").exists()).toBeTruthy();
-      expect(await link("_delete_").exists()).toBeFalsy();
+
+      expect(!(await link("_delete_").exists())).toBeTruthy();
     } catch (error) {
       await screenshot({
         path: "./tests/e2e/screenshots/delete-identity.png",

--- a/tests/e2e/delete-identity.test.ts
+++ b/tests/e2e/delete-identity.test.ts
@@ -71,7 +71,7 @@ describe("Delete Identity", () => {
       expect(!(await link("_delete_").exists())).toBeTruthy();
     } catch (error) {
       await screenshot({
-        path: "tests/e2e/screenshots/delete-identity.png",
+        path: "./tests/e2e/screenshots/delete-identity.png",
       });
 
       throw error;

--- a/tests/e2e/desktop-navigation-bar.test.ts
+++ b/tests/e2e/desktop-navigation-bar.test.ts
@@ -38,7 +38,7 @@ describe("DesktopNavigationBar", () => {
       expect(await text("LOGINS").exists()).toBeTruthy();
     } catch (error) {
       await screenshot({
-        path: "tests/e2e/screenshots/desktop_navigation_bar.png",
+        path: "./tests/e2e/screenshots/desktop_navigation_bar.png",
       });
 
       throw error;

--- a/tests/e2e/fill-incorrect-identity-input-values.test.ts
+++ b/tests/e2e/fill-incorrect-identity-input-values.test.ts
@@ -77,7 +77,7 @@ describe("Account Web Application add identity", () => {
       ).toBeTruthy();
     } catch (error) {
       await screenshot({
-        path: "tests/e2e/screenshots/fill-incorrect-add-identity-input-values.test.png",
+        path: "./tests/e2e/screenshots/fill-incorrect-add-identity-input-values.test.png",
       });
 
       throw error;
@@ -113,7 +113,7 @@ describe("Account Web Application add identity", () => {
       expect(await text("Something went wrong").exists()).toBeTruthy();
     } catch (error) {
       await screenshot({
-        path: "tests/e2e/screenshots/fill-incorrect-update-identity-input-values.test.png",
+        path: "./tests/e2e/screenshots/fill-incorrect-update-identity-input-values.test.png",
       });
 
       throw error;

--- a/tests/e2e/mark-identity-as-primary.test.ts
+++ b/tests/e2e/mark-identity-as-primary.test.ts
@@ -49,10 +49,6 @@ describe("Mark Identity as primary", () => {
       const nonPrimaryYet = await link(".test", above("Hide")).text();
       await click(nonPrimaryYet);
 
-      await screenshot({
-        path: "./tests/e2e/screenshots/mark-identity-as-primary-not-failed.test.png",
-      });
-
       expect(await text("Make").exists()).toBeTruthy();
       await click("Make");
 
@@ -61,8 +57,6 @@ describe("Mark Identity as primary", () => {
       expect(
         await text(`${nonPrimaryYet} is now your primary email`).exists(),
       ).toBeTruthy();
-
-      console.log(nonPrimaryYet);
 
       click(link(".test", below("Email addresses")), {
         waitForEvents: ["loadEventFired"],

--- a/tests/e2e/mark-identity-as-primary.test.ts
+++ b/tests/e2e/mark-identity-as-primary.test.ts
@@ -65,7 +65,7 @@ describe("Mark Identity as primary", () => {
       expect(text(nonPrimaryYet)).toBeTruthy();
     } catch (error) {
       await screenshot({
-        path: "tests/e2e/screenshots/mark-identity-as-primary.test.png",
+        path: "./tests/e2e/screenshots/mark-identity-as-primary.test.png",
       });
 
       throw error;

--- a/tests/e2e/mark-identity-as-primary.test.ts
+++ b/tests/e2e/mark-identity-as-primary.test.ts
@@ -49,6 +49,10 @@ describe("Mark Identity as primary", () => {
       const nonPrimaryYet = await link(".test", above("Hide")).text();
       await click(nonPrimaryYet);
 
+      await screenshot({
+        path: "./tests/e2e/screenshots/mark-identity-as-primary-not-failed.test.png",
+      });
+
       expect(await text("Make").exists()).toBeTruthy();
       await click("Make");
 
@@ -57,6 +61,8 @@ describe("Mark Identity as primary", () => {
       expect(
         await text(`${nonPrimaryYet} is now your primary email`).exists(),
       ).toBeTruthy();
+
+      console.log(nonPrimaryYet);
 
       click(link(".test", below("Email addresses")), {
         waitForEvents: ["loadEventFired"],

--- a/tests/e2e/mobile-navigation-bar.test.ts
+++ b/tests/e2e/mobile-navigation-bar.test.ts
@@ -39,7 +39,7 @@ describe("Log in with a smart phone, open and close the navigation bar", () => {
       expect(await text("Menu").exists()).toBeTruthy();
     } catch (error) {
       await screenshot({
-        path: "tests/e2e/screenshots/mobile_navigation_bar.png",
+        path: "./tests/e2e/screenshots/mobile_navigation_bar.png",
       });
 
       throw error;

--- a/tests/e2e/password-flow.ts
+++ b/tests/e2e/password-flow.ts
@@ -88,7 +88,7 @@ describe("Account Web Application update password", () => {
       expect(await text("Password can't be blank.").exists()).toBeTruthy();
     } catch (error) {
       await screenshot({
-        path: "tests/e2e/screenshots/fill-incorrect-new-password.test.png",
+        path: "./tests/e2e/screenshots/fill-incorrect-new-password.test.png",
       });
 
       throw error;

--- a/tests/e2e/profile-happy-path.test.ts
+++ b/tests/e2e/profile-happy-path.test.ts
@@ -52,6 +52,8 @@ describe.only("Profile Happy path", () => {
         configVariables.connectAccountURL
       ).replace(/\/?$/, "");
 
+      expect(text("Flag").exists()).toBeTruthy();
+
       // Profile creation
       if (isStagingEnv) {
         expect(await text("Create your profile").exists()).toBeTruthy();

--- a/tests/e2e/profile-happy-path.test.ts
+++ b/tests/e2e/profile-happy-path.test.ts
@@ -52,8 +52,6 @@ describe.only("Profile Happy path", () => {
         configVariables.connectAccountURL
       ).replace(/\/?$/, "");
 
-      expect(await text("Flag").exists()).toBeTruthy();
-
       // Profile creation
       if (isStagingEnv) {
         expect(await text("Create your profile").exists()).toBeTruthy();

--- a/tests/e2e/profile-happy-path.test.ts
+++ b/tests/e2e/profile-happy-path.test.ts
@@ -52,7 +52,7 @@ describe.only("Profile Happy path", () => {
         configVariables.connectAccountURL
       ).replace(/\/?$/, "");
 
-      expect(text("Flag").exists()).toBeTruthy();
+      expect(await text("Flag").exists()).toBeTruthy();
 
       // Profile creation
       if (isStagingEnv) {
@@ -209,7 +209,7 @@ describe.only("Profile Happy path", () => {
       }
     } catch (error) {
       await screenshot({
-        path: "tests/e2e/screenshots/profile-happy-path.png",
+        path: "./tests/e2e/screenshots/profile-happy-path.png",
       });
       throw error;
     }

--- a/tests/e2e/re-send-identity-validation-code.test.ts
+++ b/tests/e2e/re-send-identity-validation-code.test.ts
@@ -9,7 +9,6 @@ import {
   write,
   currentURL,
   into,
-  waitFor,
 } from "taiko";
 
 import { authenticateToConnect } from "./utils/authenticate-to-connect";
@@ -26,8 +25,8 @@ describe("Account Web Application re-send Identity validation code", () => {
         "--disable-dev-shm",
       ],
       headless: true,
-      observe: false,
-      observeTime: 1000,
+      observe: true,
+      observeTime: 500,
     });
   });
 
@@ -36,15 +35,13 @@ describe("Account Web Application re-send Identity validation code", () => {
   });
 
   test("It should re-send an Identity validation code", async () => {
-    expect.assertions(8);
+    expect.assertions(5);
 
     try {
       await authenticateToConnect();
 
-      expect(await text("LOGINS").exists()).toBeTruthy();
       await click("LOGINS");
 
-      expect(await text("+ Add new email address").exists()).toBeTruthy();
       await click(link("+ Add new email address"));
 
       expect(await text("Email address *").exists()).toBeTruthy();
@@ -56,9 +53,6 @@ describe("Account Web Application re-send Identity validation code", () => {
 
       const firstURL = await currentURL();
 
-      await waitFor(3000);
-
-      expect(await text("Resend validation code").exists()).toBeTruthy();
       await click("Resend validation code");
 
       const secondURL = await currentURL();

--- a/tests/e2e/re-send-identity-validation-code.test.ts
+++ b/tests/e2e/re-send-identity-validation-code.test.ts
@@ -65,7 +65,7 @@ describe("Account Web Application re-send Identity validation code", () => {
       expect(firstURL).not.toMatch(secondURL);
     } catch (error) {
       await screenshot({
-        path: "tests/e2e/screenshots/re-send-identity-validation-code.png",
+        path: "./tests/e2e/screenshots/re-send-identity-validation-code.png",
       });
 
       throw error;

--- a/tests/e2e/re-send-identity-validation-code.test.ts
+++ b/tests/e2e/re-send-identity-validation-code.test.ts
@@ -9,6 +9,7 @@ import {
   write,
   currentURL,
   into,
+  waitFor,
 } from "taiko";
 
 import { authenticateToConnect } from "./utils/authenticate-to-connect";
@@ -25,8 +26,8 @@ describe("Account Web Application re-send Identity validation code", () => {
         "--disable-dev-shm",
       ],
       headless: true,
-      observe: true,
-      observeTime: 500,
+      observe: false,
+      observeTime: 1000,
     });
   });
 
@@ -35,13 +36,15 @@ describe("Account Web Application re-send Identity validation code", () => {
   });
 
   test("It should re-send an Identity validation code", async () => {
-    expect.assertions(5);
+    expect.assertions(8);
 
     try {
       await authenticateToConnect();
 
+      expect(await text("LOGINS").exists()).toBeTruthy();
       await click("LOGINS");
 
+      expect(await text("+ Add new email address").exists()).toBeTruthy();
       await click(link("+ Add new email address"));
 
       expect(await text("Email address *").exists()).toBeTruthy();
@@ -53,6 +56,9 @@ describe("Account Web Application re-send Identity validation code", () => {
 
       const firstURL = await currentURL();
 
+      await waitFor(3000);
+
+      expect(await text("Resend validation code").exists()).toBeTruthy();
       await click("Resend validation code");
 
       const secondURL = await currentURL();


### PR DESCRIPTION
## Description

<!--- Include a summary of the changes, which issue is fixed and, relevant motivation and context -->
This PR adds the `store_atifacts` step in our e2e tests run in CI to upload the screenshot made in case of test failure. 

## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [ ] **Chore** (non-breaking change which refactors / improves the existing code base).
- [ ] **Bug fix** (non-breaking change which fixes an issue).
- [x] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Screenshots

<!--- if appropriate, otherwise the section can be removed -->
<img width="1397" alt="image" src="https://user-images.githubusercontent.com/50053259/122990472-432c3500-d3a4-11eb-9b95-46ec90088571.png">

## Checklist

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
