### PR TITLE
Fixing sudo mode code input display

### DIFF
--- a/src/components/forms/verify-two-fa-code-form.tsx
+++ b/src/components/forms/verify-two-fa-code-form.tsx
@@ -108,19 +108,19 @@ const ExtendedStyledForm = styled(Form)`
 const MultipleInputsMasked = styled(InputText)`
   border: 0;
   background: none;
-  letter-spacing: 4.35rem;
-  width: 85%;
+  letter-spacing: 4.65rem;
+  width: 75%;
   font-size: ${({ theme }) => theme.fontSizes.paragraph};
   font-family: monospace, monospace;
   caret-color: transparent;
   position: relative;
-  left: 1.95rem;
+  left: 2.4rem;
   margin: ${({ theme }) => theme.spaces.xs} 0;
 
   @media ${deviceBreakpoints.m} {
     letter-spacing: 3.3rem;
     width: 27rem;
-    left: 1rem;
+    left: 0.9rem;
     padding-left: 1.5rem;
   }
 `;
@@ -128,7 +128,7 @@ const MultipleInputsMasked = styled(InputText)`
 const InputMask = styled.div`
   display: flex;
   justify-content: space-between;
-  width: 75%;
+  width: 65%;
   position: absolute;
   top: 0;
   margin: ${({ theme }) => theme.spaces.xs} 0;


### PR DESCRIPTION
## Description

<!--- Include a summary of the changes, which issue is fixed and, relevant motivation and context -->
The change of our layout width some days ago broke the display of the validation code input, which is fixed in this PR.

## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [ ] **Chore** (non-breaking change which refactors / improves the existing code base).
- [x] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Screenshots

<!--- if appropriate, otherwise the section can be removed -->
<img width="436" alt="image" src="https://user-images.githubusercontent.com/50053259/123667370-62aade00-d83a-11eb-9703-18e700415bf3.png">
<img width="363" alt="image" src="https://user-images.githubusercontent.com/50053259/123667420-6e96a000-d83a-11eb-8a8e-0205c5c6cbd3.png">


## Checklist

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
