### PR TITLE
add multiple collectors config

### DIFF
--- a/src/configs/config-variables.ts
+++ b/src/configs/config-variables.ts
@@ -21,6 +21,15 @@ type ConfigVariables = {
   connectTestAccountPassword: string;
   serviceName: string;
   lightstepAccessToken: string;
+  fwlTracingCollectors: {
+    type: string;
+    serviceName: string;
+    authorizationHeader?: {
+      key: string;
+      value: string;
+    };
+    url: string;
+  }[];
   managementCredentials: {
     URI: string;
     APIKey: string;
@@ -51,6 +60,7 @@ const configVariables: ConfigVariables = {
   connectTestAccountPassword: "",
   serviceName: "",
   lightstepAccessToken: "",
+  fwlTracingCollectors: [],
   managementCredentials: {
     URI: "",
     APIKey: "",
@@ -107,6 +117,11 @@ function handleEnvVars(): void {
   configVariables.serviceName = process.env.SERVICE_NAME || "Connect.Account";
   configVariables.lightstepAccessToken =
     process.env.LIGHTSTEP_ACCESS_TOKEN || "";
+  if (process.env.FWL_TRACING_COLLECTORS) {
+    configVariables.fwlTracingCollectors = JSON.parse(
+      process.env.FWL_TRACING_COLLECTORS,
+    );
+  }
   configVariables.managementCredentials = {
     URI: process.env.CONNECT_MANAGEMENT_URL || "",
     APIKey: process.env.CONNECT_MANAGEMENT_API_KEY || "",

--- a/src/configs/config-variables.ts
+++ b/src/configs/config-variables.ts
@@ -1,3 +1,5 @@
+import { TracingConfig } from "@fwl/tracing";
+
 type ConfigVariables = {
   featureFlag: string;
   connectAccountURL: string;
@@ -21,15 +23,7 @@ type ConfigVariables = {
   connectTestAccountPassword: string;
   serviceName: string;
   lightstepAccessToken: string;
-  fwlTracingCollectors: {
-    type: string;
-    serviceName: string;
-    authorizationHeader?: {
-      key: string;
-      value: string;
-    };
-    url: string;
-  }[];
+  fwlTracingCollectors: TracingConfig["collectors"];
   managementCredentials: {
     URI: string;
     APIKey: string;

--- a/src/configs/tracer.ts
+++ b/src/configs/tracer.ts
@@ -2,21 +2,7 @@ import { getTracer, startTracer, Tracer } from "@fwl/tracing";
 
 import { configVariables } from "@src/configs/config-variables";
 
-const options = configVariables.lightstepAccessToken
-  ? {
-      lightstepPublicSatelliteCollector: {
-        serviceName: configVariables.serviceName,
-        accessToken: configVariables.lightstepAccessToken,
-      },
-    }
-  : {
-      simpleCollector: {
-        serviceName: configVariables.serviceName,
-        url: "http://localhost:29799/v1/traces",
-      },
-    };
-
-startTracer(options);
+startTracer({ collectors: configVariables.fwlTracingCollectors });
 
 function tracer(): Tracer {
   return getTracer();


### PR DESCRIPTION
## Description

This PR deals with multiple collectors setting for `fwl/tracing`

It adds a new environment variable, like this:

```json
'[{"serviceName":"Connect.Account","accessToken":"🙈"}]'
```

then parse it to obtain the `[]` with all the collectors.

## Type of change

- [x] **Chore** (non-breaking change which refactors / improves the existing code base).
- [ ] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Issues

[CU-kn503a](https://app.clickup.com/t/kn503a)

## Checklist

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
