### PR TITLE
empty commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,28 +53,28 @@ jobs:
       - run: 
           name: Preparing test user
           command: yarn e2e:setting-sudo-ttl
-      - when: 
-          condition: 
-            matches: { pattern: ".*?\\bstaging\\b.*?", value: << pipeline.parameters.target_url >> }
-          steps:
-            - run: 
-                name: Setting Profile and Account staging URL env var
-                command: |
-                  echo "export CONNECT_PROFILE_URL=https://fewlines-profile-staging.herokuapp.com/" >> $BASH_ENV
-                  echo "export CONNECT_TEST_ACCOUNT_URL=https://account-staging.fewlines.tech/" >> $BASH_ENV
+      # - when: 
+      #     condition: 
+      #       matches: { pattern: ".*?\\bstaging\\b.*?", value: << pipeline.parameters.target_url >> }
+          # steps:
+      - run: 
+          name: Setting Profile and Account staging URL env var
+          command: |
+            echo "export CONNECT_PROFILE_URL=https://fewlines-profile-staging.herokuapp.com/" >> $BASH_ENV
+            echo "export CONNECT_TEST_ACCOUNT_URL=https://account-staging.fewlines.tech/" >> $BASH_ENV
       - run:
           name: Running e2e tests
-          command: CONNECT_TEST_ACCOUNT_EMAIL="taiko_${CIRCLE_SHA1}@fewlines.test" DEBUG="taiko:*" yarn test:e2e 
+          command: CONNECT_TEST_ACCOUNT_EMAIL="taiko_${CIRCLE_SHA1}@fewlines.test" yarn test:e2e 
       - store_artifacts:
           path: ./tests/e2e/screenshots
-      - when: 
-          condition: 
-            matches: { pattern: ".*?\\bstaging\\b.*?", value: << pipeline.parameters.target_url >> }
-          steps:
-            - run: 
-                name: Cleaning Profile Staging
-                command: yarn e2e:delete-profile-user
-                when: always
+      # - when: 
+      #     condition: 
+      #       matches: { pattern: ".*?\\bstaging\\b.*?", value: << pipeline.parameters.target_url >> }
+      #     steps:
+      - run: 
+          name: Cleaning Profile Staging
+          command: yarn e2e:delete-profile-user
+          when: always
       - run: 
           name: Removing Connect test user
           command: yarn e2e:remove-test-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,28 +53,28 @@ jobs:
       - run: 
           name: Preparing test user
           command: yarn e2e:setting-sudo-ttl
-      # - when: 
-      #     condition: 
-      #       matches: { pattern: ".*?\\bstaging\\b.*?", value: << pipeline.parameters.target_url >> }
-          # steps:
-      - run: 
-          name: Setting Profile and Account staging URL env var
-          command: |
-            echo "export CONNECT_PROFILE_URL=https://fewlines-profile-staging.herokuapp.com/" >> $BASH_ENV
-            echo "export CONNECT_TEST_ACCOUNT_URL=https://account-staging.fewlines.tech/" >> $BASH_ENV
+      - when: 
+          condition: 
+            matches: { pattern: ".*?\\bstaging\\b.*?", value: << pipeline.parameters.target_url >> }
+          steps:
+            - run: 
+                name: Setting Profile and Account staging URL env var
+                command: |
+                  echo "export CONNECT_PROFILE_URL=https://fewlines-profile-staging.herokuapp.com/" >> $BASH_ENV
+                  echo "export CONNECT_TEST_ACCOUNT_URL=https://account-staging.fewlines.tech/" >> $BASH_ENV
       - run:
           name: Running e2e tests
           command: CONNECT_TEST_ACCOUNT_EMAIL="taiko_${CIRCLE_SHA1}@fewlines.test" yarn test:e2e 
       - store_artifacts:
           path: ./tests/e2e/screenshots
-      # - when: 
-      #     condition: 
-      #       matches: { pattern: ".*?\\bstaging\\b.*?", value: << pipeline.parameters.target_url >> }
-      #     steps:
-      - run: 
-          name: Cleaning Profile Staging
-          command: yarn e2e:delete-profile-user
-          when: always
+      - when: 
+          condition: 
+            matches: { pattern: ".*?\\bstaging\\b.*?", value: << pipeline.parameters.target_url >> }
+          steps:
+            - run: 
+                name: Cleaning Profile Staging
+                command: yarn e2e:delete-profile-user
+                when: always
       - run: 
           name: Removing Connect test user
           command: yarn e2e:remove-test-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
                   echo "export CONNECT_TEST_ACCOUNT_URL=https://account-staging.fewlines.tech/" >> $BASH_ENV
       - run:
           name: Running e2e tests
-          command: CONNECT_TEST_ACCOUNT_EMAIL="taiko_${CIRCLE_SHA1}@fewlines.test" yarn test:e2e 
+          command: CONNECT_TEST_ACCOUNT_EMAIL="taiko_${CIRCLE_SHA1}@fewlines.test" DEBUG="taiko:*" yarn test:e2e 
       - store_artifacts:
           path: ./tests/e2e/screenshots
       - when: 

--- a/tests/e2e/fill-incorrect-identity-input-values.test.ts
+++ b/tests/e2e/fill-incorrect-identity-input-values.test.ts
@@ -37,10 +37,6 @@ describe("Fill incorrect identity input values", () => {
     await closeBrowser();
   });
 
-  beforeEach(async () => {
-    await authenticateToConnect();
-  });
-
   const localizedErrorStrings = locales.en.errors;
   const localizedStrings = {
     accountOverview: locales.en["/account"],
@@ -54,6 +50,7 @@ describe("Fill incorrect identity input values", () => {
     test("It should show error messages if Identity inputs are filled incorrectly in add identity", async () => {
       expect.assertions(6);
       try {
+        await authenticateToConnect();
         await click(localizedStrings.accountOverview.loginsTitle);
 
         await click(

--- a/tests/e2e/profile-happy-path.test.ts
+++ b/tests/e2e/profile-happy-path.test.ts
@@ -12,7 +12,6 @@ import {
   below,
   currentURL,
   waitFor,
-  goto,
 } from "taiko";
 
 import { authenticateToConnect } from "./utils/authenticate-to-connect";
@@ -65,7 +64,7 @@ describe("Profile happy path", () => {
   });
 
   test("it should do Profile flows' happy path", async () => {
-    expect.assertions(isStagingEnv ? 3 : 2);
+    expect.assertions(isStagingEnv ? 21 : 14);
     try {
       // Profile creation
       if (isStagingEnv) {
@@ -120,19 +119,6 @@ describe("Profile happy path", () => {
 
       await click(localizedStrings.editProfile.update);
       expect(await currentURL()).toEqual(`${baseURL}/account/profile`);
-    } catch (error) {
-      await screenshot({
-        path: "./tests/e2e/screenshots/profile-happy-path.png",
-      });
-      throw error;
-    }
-  });
-
-  test("it should do Addresses flows' happy path", async () => {
-    expect.assertions(isStagingEnv ? 18 : 12);
-    try {
-      // Add address flow
-      await goto(profileUrl);
 
       await click(text(localizedStrings.profileOverview.addAddress));
 
@@ -319,7 +305,7 @@ describe("Profile happy path", () => {
       }
     } catch (error) {
       await screenshot({
-        path: "./tests/e2e/screenshots/addresses-happy-path.png",
+        path: "./tests/e2e/screenshots/profile-happy-path.png",
       });
       throw error;
     }


### PR DESCRIPTION
## Description

This PR removes `authenticateToConnect` from `beforeEach` hook in tests otherwise they fail each time there's 2 e2e test in one file.

It seems that taiko successfully uses the `goto` but fail for a reason I don't get.

## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] **Chore** (non-breaking change which refactors / improves the existing code base).
- [x] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Issues

[CU-9u11zz](https://app.clickup.com/t/9u11zz)

## Checklist

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
