### PR TITLE
bump tracing to 0.10.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@fewlines/connect-management": "0.7.0",
     "@formatjs/intl": "1.13.4",
     "@fwl/logging": "0.1.2",
-    "@fwl/tracing": "0.10.2",
+    "@fwl/tracing": "0.10.3",
     "@fwl/web": "0.13.0",
     "@hapi/iron": "6.0.0",
     "@react-aria/button": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@fewlines/connect-management": "0.7.0",
     "@formatjs/intl": "1.13.4",
     "@fwl/logging": "0.1.2",
-    "@fwl/tracing": "0.10.3",
+    "@fwl/tracing": "0.10.2",
     "@fwl/web": "0.13.0",
     "@hapi/iron": "6.0.0",
     "@react-aria/button": "3.3.2",

--- a/src/configs/tracer.ts
+++ b/src/configs/tracer.ts
@@ -2,8 +2,6 @@ import { getTracer, startTracer, Tracer } from "@fwl/tracing";
 
 import { configVariables } from "@src/configs/config-variables";
 
-console.log(configVariables);
-
 startTracer({ collectors: configVariables.fwlTracingCollectors });
 
 function tracer(): Tracer {

--- a/src/configs/tracer.ts
+++ b/src/configs/tracer.ts
@@ -2,6 +2,8 @@ import { getTracer, startTracer, Tracer } from "@fwl/tracing";
 
 import { configVariables } from "@src/configs/config-variables";
 
+console.log(configVariables);
+
 startTracer({ collectors: configVariables.fwlTracingCollectors });
 
 function tracer(): Tracer {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2020,21 +2020,23 @@
     "@opentelemetry/plugin-https" "0.18.2"
     "@opentelemetry/tracing" "0.19.0"
 
-"@fwl/tracing@0.10.2":
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@fwl/tracing/-/tracing-0.10.2.tgz#1ac6aa2e5d4bb068c253ce3c6937922ed8adcbee"
-  integrity sha512-YS/Tnj65WJ+r9B02lr+t4niI8OaAnz1TjCYzYWh5f4kyzgewUAdqu3tFhd2sdxUHip0a+MsdvetGideAkNz2nQ==
+"@fwl/tracing@0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@fwl/tracing/-/tracing-0.10.3.tgz#88152f33b343432e13b3dbe3db82a7d9e3e33df9"
+  integrity sha512-5ffYsJOCWzYNaViu1mAl33X8EDCxamgJBPHufsDASxoFJjWD+WLTWUXZ6FbVmhrCFkpsetGsZyRbABaZnRpTyg==
   dependencies:
     "@fwl/logging" "0.1.2"
-    "@opentelemetry/api" "1.0.0-rc.3"
-    "@opentelemetry/context-async-hooks" "0.19.0"
-    "@opentelemetry/core" "0.19.0"
-    "@opentelemetry/exporter-collector" "0.19.0"
-    "@opentelemetry/exporter-zipkin" "0.19.0"
-    "@opentelemetry/node" "0.19.0"
+    "@opentelemetry/api" "1.0.1"
+    "@opentelemetry/context-async-hooks" "0.23.0"
+    "@opentelemetry/core" "0.23.0"
+    "@opentelemetry/exporter-collector" "0.23.0"
+    "@opentelemetry/exporter-zipkin" "0.23.0"
+    "@opentelemetry/node" "0.23.0"
     "@opentelemetry/plugin-http" "0.18.2"
     "@opentelemetry/plugin-https" "0.18.2"
-    "@opentelemetry/tracing" "0.19.0"
+    "@opentelemetry/resources" "0.23.0"
+    "@opentelemetry/semantic-conventions" "0.23.0"
+    "@opentelemetry/tracing" "0.23.0"
 
 "@fwl/web@0.13.0":
   version "0.13.0"
@@ -2460,6 +2462,11 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api-metrics/-/api-metrics-0.19.0.tgz#3b5944ce86f4551cbff1afdc1d064adf18a2db68"
   integrity sha512-1JpnkwCkYgZvbcHkF0nNK6RkMqoEx7zxM3oyMEkFNT7F4nh4tFMDHJ+BRelMk8kzeYtnyZ0YCshhO9xS3SXSHQ==
 
+"@opentelemetry/api-metrics@0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api-metrics/-/api-metrics-0.23.0.tgz#5b0bae3cee1bab2993aebd44275788577761d1d4"
+  integrity sha512-MGfH9aMnVktRTagYHvhksrk42vPDjTIz5N6Cxu31t6dgJa6iUYR6MemnOdphyLk73DUaqmR5s2Fn6jg0Xd9gqA==
+
 "@opentelemetry/api@0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-0.14.0.tgz#4e17d8d2f1da72b19374efa7b6526aa001267cae"
@@ -2472,6 +2479,11 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.0.0-rc.3.tgz#903ef6dddf04410d09072d43a060b87ccc162545"
   integrity sha512-3PlJD9uN5iZrKmX054vOifGxZ/iH24+UFD5eW8Vyz08GUU7SdW8PNu4VSpTixWeuWo+Q6TELfSv7vVu43t+tbA==
 
+"@opentelemetry/api@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.0.1.tgz#03c72f548431da5820a0c8864d1401e348e7e79f"
+  integrity sha512-H5Djcc2txGAINgf3TNaq4yFofYSIK3722PM89S/3R8FuI/eqi1UscajlXk7EBkG9s2pxss/q6SHlpturaavXaw==
+
 "@opentelemetry/api@^0.18.1":
   version "0.18.1"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-0.18.1.tgz#fb499e07afa1f55acffc47b2469eb218dcdee2a2"
@@ -2481,6 +2493,11 @@
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/context-async-hooks/-/context-async-hooks-0.19.0.tgz#b959b6c880c8914f931a527051da86cb3171d0eb"
   integrity sha512-+lkG1nw3XJMm5dkOlwa9tZ6PQOJmH8moMEXzty10PlmvTcJgIq+gW8iHIPLocNTkuKKh+B/vNDVURJOSarAJUg==
+
+"@opentelemetry/context-async-hooks@0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/context-async-hooks/-/context-async-hooks-0.23.0.tgz#dadc81447790ce664b4bd2617cef9ff3cf9d4b17"
+  integrity sha512-aM+sSnNe5GL66KaHx4QJFVOvK817LE32bhc29BW9KlamieqxfDnSelPoNPra85FWlxzLXPGowU7sW5rexSRAtA==
 
 "@opentelemetry/context-base@^0.14.0":
   version "0.14.0"
@@ -2492,6 +2509,14 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-0.19.0.tgz#5018e16d1d3081da0657476e58d9c2dce7c511a2"
   integrity sha512-t83FleVbHH6SWdUegclZbsnHn0OaHjq17Hd1zsJIRMM6WNuVzbXWA+3V6LCKXqUYyu3qwtZ/w45u/Nqfr5mEeQ==
   dependencies:
+    semver "^7.1.3"
+
+"@opentelemetry/core@0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-0.23.0.tgz#611a39255ac8296a79fbc6548a6d3b1bc87ee17e"
+  integrity sha512-7COVsnGEW96ITjc0waWYo/R27sFqjPUg4SCoP8XL48zAGr9zjzeuJoQe/xVchs7op//qOeeEEeBxiBvXy2QS0Q==
+  dependencies:
+    "@opentelemetry/semantic-conventions" "0.23.0"
     semver "^7.1.3"
 
 "@opentelemetry/core@^0.18.2":
@@ -2513,6 +2538,17 @@
     "@opentelemetry/resources" "0.19.0"
     "@opentelemetry/tracing" "0.19.0"
 
+"@opentelemetry/exporter-collector@0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-collector/-/exporter-collector-0.23.0.tgz#7ee7b96c61f1b148eba22fa173bf74ec44bd6164"
+  integrity sha512-rDy0sFSy8uUQH5i3JntVjjsUJfRaHoeMXrByl5ejuHtNRleGidx9UIZK0oSZMRvK/5lFvvJJrQFMhZQyppDfsw==
+  dependencies:
+    "@opentelemetry/api-metrics" "0.23.0"
+    "@opentelemetry/core" "0.23.0"
+    "@opentelemetry/metrics" "0.23.0"
+    "@opentelemetry/resources" "0.23.0"
+    "@opentelemetry/tracing" "0.23.0"
+
 "@opentelemetry/exporter-zipkin@0.19.0":
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-zipkin/-/exporter-zipkin-0.19.0.tgz#ec981dfb00ca0a19863247dec7376c04e3111ebb"
@@ -2522,6 +2558,16 @@
     "@opentelemetry/resources" "0.19.0"
     "@opentelemetry/tracing" "0.19.0"
 
+"@opentelemetry/exporter-zipkin@0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-zipkin/-/exporter-zipkin-0.23.0.tgz#a4a5022296bf5ab102e2fd3ca85a4835046f223b"
+  integrity sha512-sdqW6FkvwDKv8fKmOsDRfmzpLJMaZR+KJ2cMUHb87cpzXhwulF2Ifdq622wsCsm4JFvV+/FHWZTgn1s6TLf3+A==
+  dependencies:
+    "@opentelemetry/core" "0.23.0"
+    "@opentelemetry/resources" "0.23.0"
+    "@opentelemetry/semantic-conventions" "0.23.0"
+    "@opentelemetry/tracing" "0.23.0"
+
 "@opentelemetry/metrics@0.19.0":
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/metrics/-/metrics-0.19.0.tgz#8ec409202a373a09b505261d7749f3bb29e1447d"
@@ -2530,6 +2576,16 @@
     "@opentelemetry/api-metrics" "0.19.0"
     "@opentelemetry/core" "0.19.0"
     "@opentelemetry/resources" "0.19.0"
+    lodash.merge "^4.6.2"
+
+"@opentelemetry/metrics@0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/metrics/-/metrics-0.23.0.tgz#3c64d8b86ff4952c91aa9010fdf1c76783b33fe1"
+  integrity sha512-IRl/AfnNFmmNZrM58R2T/gVqatPve+T2EpaBbWv4zVfY9Q2S8q7oT8HZAPUc/GQTb2pvwLXpcKO8QmeEt4gfHQ==
+  dependencies:
+    "@opentelemetry/api-metrics" "0.23.0"
+    "@opentelemetry/core" "0.23.0"
+    "@opentelemetry/resources" "0.23.0"
     lodash.merge "^4.6.2"
 
 "@opentelemetry/node@0.19.0":
@@ -2542,6 +2598,18 @@
     "@opentelemetry/propagator-b3" "0.19.0"
     "@opentelemetry/propagator-jaeger" "0.19.0"
     "@opentelemetry/tracing" "0.19.0"
+    semver "^7.1.3"
+
+"@opentelemetry/node@0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/node/-/node-0.23.0.tgz#6bcc8ee685098cc369ff00859a7a654bc586d103"
+  integrity sha512-StG3UQmcm/D6ZCoiAvNcFN1K9pm4zIf+uzS7L2HToOh83iwjvBYuMDwMPNTSH8eKM+2+OYOVtud4bn9wF5aLGA==
+  dependencies:
+    "@opentelemetry/context-async-hooks" "0.23.0"
+    "@opentelemetry/core" "0.23.0"
+    "@opentelemetry/propagator-b3" "0.23.0"
+    "@opentelemetry/propagator-jaeger" "0.23.0"
+    "@opentelemetry/tracing" "0.23.0"
     semver "^7.1.3"
 
 "@opentelemetry/plugin-http@0.18.2", "@opentelemetry/plugin-http@^0.18.2":
@@ -2572,12 +2640,26 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/propagator-b3/-/propagator-b3-0.19.0.tgz#0e6876b0705b4c356ed41498fe328c13ef78afdb"
   integrity sha512-/4ef5RA5xtzPAdtab9ml49DUd8I9mtLtUb3k3HfNYAy5RkJfJ5j4lpnUe0ZFPCOsonGyFHjtkN4s1j9MGHT5cQ==
 
+"@opentelemetry/propagator-b3@0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/propagator-b3/-/propagator-b3-0.23.0.tgz#e911363bceef7238f1f7c94b0e6da6c46085d935"
+  integrity sha512-bXojPjqncbhZtsX1tmIMB/dVLXI8ByoLLTBSHd5z6vJQA66LYtJX89xlIVZfiwuWIePqUnBJTmGEK95bDem6uw==
+  dependencies:
+    "@opentelemetry/core" "0.23.0"
+
 "@opentelemetry/propagator-jaeger@0.19.0":
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/propagator-jaeger/-/propagator-jaeger-0.19.0.tgz#67e5ce09869470ca6cb1ed279a665ce2084aeb51"
   integrity sha512-y2HgU5JzBKIJvRnlhRdcnokWKe7doWlBK60bTWawMYhThproa5Pn4h7dOKSnvtcBljhugXqkfhI8nkg3Syzwyw==
   dependencies:
     "@opentelemetry/core" "0.19.0"
+
+"@opentelemetry/propagator-jaeger@0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/propagator-jaeger/-/propagator-jaeger-0.23.0.tgz#1c6c6216e5bdf9b3f65a72f0cedcc3a8947e5818"
+  integrity sha512-N94k3dwnA4KeTUp2BE2ytADp4XYU4EWreo1tVwBVDpowjXY9WkVsDsZD6QA/PUvJJQZCzexSS5ERnHGoVRcOmQ==
+  dependencies:
+    "@opentelemetry/core" "0.23.0"
 
 "@opentelemetry/resources@0.19.0":
   version "0.19.0"
@@ -2586,10 +2668,23 @@
   dependencies:
     "@opentelemetry/core" "0.19.0"
 
+"@opentelemetry/resources@0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-0.23.0.tgz#221c123306708ceac707599e3a201896b953f53b"
+  integrity sha512-sAiaoQ0pOwjaaKySuwCUlvej/W9M5d+SxpcuBFUBUojqRlEAYDbx1FHClPnKtOysIb9rXJDQvM3xlH++7NQQzg==
+  dependencies:
+    "@opentelemetry/core" "0.23.0"
+    "@opentelemetry/semantic-conventions" "0.23.0"
+
 "@opentelemetry/semantic-conventions@0.19.0":
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-0.19.0.tgz#3e49b45b52426c62740a24fcf5818cb690b446ef"
   integrity sha512-MMXhYEvNakvXC+oa5muX8KS2z+rsXLXwabjuzXcbJPH+rvo5XFNQ1c7svxb0B1xPpm4KT7fnH2DVfYqQzsCteQ==
+
+"@opentelemetry/semantic-conventions@0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-0.23.0.tgz#ec1467fd71f6551628b60cd2107acc923b9b77cc"
+  integrity sha512-Tzo+VGR1zlzLbjVI+7mlDJ2xuaUsue4scWvFlK+fzcUfn9siF4NWbxoC2X6Br2B/g4dsq1OAwAYsPVYIEoY2rQ==
 
 "@opentelemetry/semantic-conventions@^0.18.2":
   version "0.18.2"
@@ -2604,6 +2699,16 @@
     "@opentelemetry/core" "0.19.0"
     "@opentelemetry/resources" "0.19.0"
     "@opentelemetry/semantic-conventions" "0.19.0"
+    lodash.merge "^4.6.2"
+
+"@opentelemetry/tracing@0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/tracing/-/tracing-0.23.0.tgz#bf80a987f57508f2202170f4f2bc4385988ecb02"
+  integrity sha512-3vNLS55bE0CG1RBDz7+wAAKpLjbl8fhQKqM4MvTy/LYHSolgyM5BNutSb/TcA9LtWvkdI0djgFXxeRig1OFqoQ==
+  dependencies:
+    "@opentelemetry/core" "0.23.0"
+    "@opentelemetry/resources" "0.23.0"
+    "@opentelemetry/semantic-conventions" "0.23.0"
     lodash.merge "^4.6.2"
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.4.3":

--- a/yarn.lock
+++ b/yarn.lock
@@ -2020,23 +2020,21 @@
     "@opentelemetry/plugin-https" "0.18.2"
     "@opentelemetry/tracing" "0.19.0"
 
-"@fwl/tracing@0.10.3":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/@fwl/tracing/-/tracing-0.10.3.tgz#88152f33b343432e13b3dbe3db82a7d9e3e33df9"
-  integrity sha512-5ffYsJOCWzYNaViu1mAl33X8EDCxamgJBPHufsDASxoFJjWD+WLTWUXZ6FbVmhrCFkpsetGsZyRbABaZnRpTyg==
+"@fwl/tracing@0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@fwl/tracing/-/tracing-0.10.2.tgz#1ac6aa2e5d4bb068c253ce3c6937922ed8adcbee"
+  integrity sha512-YS/Tnj65WJ+r9B02lr+t4niI8OaAnz1TjCYzYWh5f4kyzgewUAdqu3tFhd2sdxUHip0a+MsdvetGideAkNz2nQ==
   dependencies:
     "@fwl/logging" "0.1.2"
-    "@opentelemetry/api" "1.0.1"
-    "@opentelemetry/context-async-hooks" "0.23.0"
-    "@opentelemetry/core" "0.23.0"
-    "@opentelemetry/exporter-collector" "0.23.0"
-    "@opentelemetry/exporter-zipkin" "0.23.0"
-    "@opentelemetry/node" "0.23.0"
+    "@opentelemetry/api" "1.0.0-rc.3"
+    "@opentelemetry/context-async-hooks" "0.19.0"
+    "@opentelemetry/core" "0.19.0"
+    "@opentelemetry/exporter-collector" "0.19.0"
+    "@opentelemetry/exporter-zipkin" "0.19.0"
+    "@opentelemetry/node" "0.19.0"
     "@opentelemetry/plugin-http" "0.18.2"
     "@opentelemetry/plugin-https" "0.18.2"
-    "@opentelemetry/resources" "0.23.0"
-    "@opentelemetry/semantic-conventions" "0.23.0"
-    "@opentelemetry/tracing" "0.23.0"
+    "@opentelemetry/tracing" "0.19.0"
 
 "@fwl/web@0.13.0":
   version "0.13.0"
@@ -2462,11 +2460,6 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api-metrics/-/api-metrics-0.19.0.tgz#3b5944ce86f4551cbff1afdc1d064adf18a2db68"
   integrity sha512-1JpnkwCkYgZvbcHkF0nNK6RkMqoEx7zxM3oyMEkFNT7F4nh4tFMDHJ+BRelMk8kzeYtnyZ0YCshhO9xS3SXSHQ==
 
-"@opentelemetry/api-metrics@0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api-metrics/-/api-metrics-0.23.0.tgz#5b0bae3cee1bab2993aebd44275788577761d1d4"
-  integrity sha512-MGfH9aMnVktRTagYHvhksrk42vPDjTIz5N6Cxu31t6dgJa6iUYR6MemnOdphyLk73DUaqmR5s2Fn6jg0Xd9gqA==
-
 "@opentelemetry/api@0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-0.14.0.tgz#4e17d8d2f1da72b19374efa7b6526aa001267cae"
@@ -2479,11 +2472,6 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.0.0-rc.3.tgz#903ef6dddf04410d09072d43a060b87ccc162545"
   integrity sha512-3PlJD9uN5iZrKmX054vOifGxZ/iH24+UFD5eW8Vyz08GUU7SdW8PNu4VSpTixWeuWo+Q6TELfSv7vVu43t+tbA==
 
-"@opentelemetry/api@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.0.1.tgz#03c72f548431da5820a0c8864d1401e348e7e79f"
-  integrity sha512-H5Djcc2txGAINgf3TNaq4yFofYSIK3722PM89S/3R8FuI/eqi1UscajlXk7EBkG9s2pxss/q6SHlpturaavXaw==
-
 "@opentelemetry/api@^0.18.1":
   version "0.18.1"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-0.18.1.tgz#fb499e07afa1f55acffc47b2469eb218dcdee2a2"
@@ -2493,11 +2481,6 @@
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/context-async-hooks/-/context-async-hooks-0.19.0.tgz#b959b6c880c8914f931a527051da86cb3171d0eb"
   integrity sha512-+lkG1nw3XJMm5dkOlwa9tZ6PQOJmH8moMEXzty10PlmvTcJgIq+gW8iHIPLocNTkuKKh+B/vNDVURJOSarAJUg==
-
-"@opentelemetry/context-async-hooks@0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/context-async-hooks/-/context-async-hooks-0.23.0.tgz#dadc81447790ce664b4bd2617cef9ff3cf9d4b17"
-  integrity sha512-aM+sSnNe5GL66KaHx4QJFVOvK817LE32bhc29BW9KlamieqxfDnSelPoNPra85FWlxzLXPGowU7sW5rexSRAtA==
 
 "@opentelemetry/context-base@^0.14.0":
   version "0.14.0"
@@ -2509,14 +2492,6 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-0.19.0.tgz#5018e16d1d3081da0657476e58d9c2dce7c511a2"
   integrity sha512-t83FleVbHH6SWdUegclZbsnHn0OaHjq17Hd1zsJIRMM6WNuVzbXWA+3V6LCKXqUYyu3qwtZ/w45u/Nqfr5mEeQ==
   dependencies:
-    semver "^7.1.3"
-
-"@opentelemetry/core@0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-0.23.0.tgz#611a39255ac8296a79fbc6548a6d3b1bc87ee17e"
-  integrity sha512-7COVsnGEW96ITjc0waWYo/R27sFqjPUg4SCoP8XL48zAGr9zjzeuJoQe/xVchs7op//qOeeEEeBxiBvXy2QS0Q==
-  dependencies:
-    "@opentelemetry/semantic-conventions" "0.23.0"
     semver "^7.1.3"
 
 "@opentelemetry/core@^0.18.2":
@@ -2538,17 +2513,6 @@
     "@opentelemetry/resources" "0.19.0"
     "@opentelemetry/tracing" "0.19.0"
 
-"@opentelemetry/exporter-collector@0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-collector/-/exporter-collector-0.23.0.tgz#7ee7b96c61f1b148eba22fa173bf74ec44bd6164"
-  integrity sha512-rDy0sFSy8uUQH5i3JntVjjsUJfRaHoeMXrByl5ejuHtNRleGidx9UIZK0oSZMRvK/5lFvvJJrQFMhZQyppDfsw==
-  dependencies:
-    "@opentelemetry/api-metrics" "0.23.0"
-    "@opentelemetry/core" "0.23.0"
-    "@opentelemetry/metrics" "0.23.0"
-    "@opentelemetry/resources" "0.23.0"
-    "@opentelemetry/tracing" "0.23.0"
-
 "@opentelemetry/exporter-zipkin@0.19.0":
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-zipkin/-/exporter-zipkin-0.19.0.tgz#ec981dfb00ca0a19863247dec7376c04e3111ebb"
@@ -2558,16 +2522,6 @@
     "@opentelemetry/resources" "0.19.0"
     "@opentelemetry/tracing" "0.19.0"
 
-"@opentelemetry/exporter-zipkin@0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-zipkin/-/exporter-zipkin-0.23.0.tgz#a4a5022296bf5ab102e2fd3ca85a4835046f223b"
-  integrity sha512-sdqW6FkvwDKv8fKmOsDRfmzpLJMaZR+KJ2cMUHb87cpzXhwulF2Ifdq622wsCsm4JFvV+/FHWZTgn1s6TLf3+A==
-  dependencies:
-    "@opentelemetry/core" "0.23.0"
-    "@opentelemetry/resources" "0.23.0"
-    "@opentelemetry/semantic-conventions" "0.23.0"
-    "@opentelemetry/tracing" "0.23.0"
-
 "@opentelemetry/metrics@0.19.0":
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/metrics/-/metrics-0.19.0.tgz#8ec409202a373a09b505261d7749f3bb29e1447d"
@@ -2576,16 +2530,6 @@
     "@opentelemetry/api-metrics" "0.19.0"
     "@opentelemetry/core" "0.19.0"
     "@opentelemetry/resources" "0.19.0"
-    lodash.merge "^4.6.2"
-
-"@opentelemetry/metrics@0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/metrics/-/metrics-0.23.0.tgz#3c64d8b86ff4952c91aa9010fdf1c76783b33fe1"
-  integrity sha512-IRl/AfnNFmmNZrM58R2T/gVqatPve+T2EpaBbWv4zVfY9Q2S8q7oT8HZAPUc/GQTb2pvwLXpcKO8QmeEt4gfHQ==
-  dependencies:
-    "@opentelemetry/api-metrics" "0.23.0"
-    "@opentelemetry/core" "0.23.0"
-    "@opentelemetry/resources" "0.23.0"
     lodash.merge "^4.6.2"
 
 "@opentelemetry/node@0.19.0":
@@ -2598,18 +2542,6 @@
     "@opentelemetry/propagator-b3" "0.19.0"
     "@opentelemetry/propagator-jaeger" "0.19.0"
     "@opentelemetry/tracing" "0.19.0"
-    semver "^7.1.3"
-
-"@opentelemetry/node@0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/node/-/node-0.23.0.tgz#6bcc8ee685098cc369ff00859a7a654bc586d103"
-  integrity sha512-StG3UQmcm/D6ZCoiAvNcFN1K9pm4zIf+uzS7L2HToOh83iwjvBYuMDwMPNTSH8eKM+2+OYOVtud4bn9wF5aLGA==
-  dependencies:
-    "@opentelemetry/context-async-hooks" "0.23.0"
-    "@opentelemetry/core" "0.23.0"
-    "@opentelemetry/propagator-b3" "0.23.0"
-    "@opentelemetry/propagator-jaeger" "0.23.0"
-    "@opentelemetry/tracing" "0.23.0"
     semver "^7.1.3"
 
 "@opentelemetry/plugin-http@0.18.2", "@opentelemetry/plugin-http@^0.18.2":
@@ -2640,26 +2572,12 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/propagator-b3/-/propagator-b3-0.19.0.tgz#0e6876b0705b4c356ed41498fe328c13ef78afdb"
   integrity sha512-/4ef5RA5xtzPAdtab9ml49DUd8I9mtLtUb3k3HfNYAy5RkJfJ5j4lpnUe0ZFPCOsonGyFHjtkN4s1j9MGHT5cQ==
 
-"@opentelemetry/propagator-b3@0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/propagator-b3/-/propagator-b3-0.23.0.tgz#e911363bceef7238f1f7c94b0e6da6c46085d935"
-  integrity sha512-bXojPjqncbhZtsX1tmIMB/dVLXI8ByoLLTBSHd5z6vJQA66LYtJX89xlIVZfiwuWIePqUnBJTmGEK95bDem6uw==
-  dependencies:
-    "@opentelemetry/core" "0.23.0"
-
 "@opentelemetry/propagator-jaeger@0.19.0":
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/propagator-jaeger/-/propagator-jaeger-0.19.0.tgz#67e5ce09869470ca6cb1ed279a665ce2084aeb51"
   integrity sha512-y2HgU5JzBKIJvRnlhRdcnokWKe7doWlBK60bTWawMYhThproa5Pn4h7dOKSnvtcBljhugXqkfhI8nkg3Syzwyw==
   dependencies:
     "@opentelemetry/core" "0.19.0"
-
-"@opentelemetry/propagator-jaeger@0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/propagator-jaeger/-/propagator-jaeger-0.23.0.tgz#1c6c6216e5bdf9b3f65a72f0cedcc3a8947e5818"
-  integrity sha512-N94k3dwnA4KeTUp2BE2ytADp4XYU4EWreo1tVwBVDpowjXY9WkVsDsZD6QA/PUvJJQZCzexSS5ERnHGoVRcOmQ==
-  dependencies:
-    "@opentelemetry/core" "0.23.0"
 
 "@opentelemetry/resources@0.19.0":
   version "0.19.0"
@@ -2668,23 +2586,10 @@
   dependencies:
     "@opentelemetry/core" "0.19.0"
 
-"@opentelemetry/resources@0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-0.23.0.tgz#221c123306708ceac707599e3a201896b953f53b"
-  integrity sha512-sAiaoQ0pOwjaaKySuwCUlvej/W9M5d+SxpcuBFUBUojqRlEAYDbx1FHClPnKtOysIb9rXJDQvM3xlH++7NQQzg==
-  dependencies:
-    "@opentelemetry/core" "0.23.0"
-    "@opentelemetry/semantic-conventions" "0.23.0"
-
 "@opentelemetry/semantic-conventions@0.19.0":
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-0.19.0.tgz#3e49b45b52426c62740a24fcf5818cb690b446ef"
   integrity sha512-MMXhYEvNakvXC+oa5muX8KS2z+rsXLXwabjuzXcbJPH+rvo5XFNQ1c7svxb0B1xPpm4KT7fnH2DVfYqQzsCteQ==
-
-"@opentelemetry/semantic-conventions@0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-0.23.0.tgz#ec1467fd71f6551628b60cd2107acc923b9b77cc"
-  integrity sha512-Tzo+VGR1zlzLbjVI+7mlDJ2xuaUsue4scWvFlK+fzcUfn9siF4NWbxoC2X6Br2B/g4dsq1OAwAYsPVYIEoY2rQ==
 
 "@opentelemetry/semantic-conventions@^0.18.2":
   version "0.18.2"
@@ -2699,16 +2604,6 @@
     "@opentelemetry/core" "0.19.0"
     "@opentelemetry/resources" "0.19.0"
     "@opentelemetry/semantic-conventions" "0.19.0"
-    lodash.merge "^4.6.2"
-
-"@opentelemetry/tracing@0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/tracing/-/tracing-0.23.0.tgz#bf80a987f57508f2202170f4f2bc4385988ecb02"
-  integrity sha512-3vNLS55bE0CG1RBDz7+wAAKpLjbl8fhQKqM4MvTy/LYHSolgyM5BNutSb/TcA9LtWvkdI0djgFXxeRig1OFqoQ==
-  dependencies:
-    "@opentelemetry/core" "0.23.0"
-    "@opentelemetry/resources" "0.23.0"
-    "@opentelemetry/semantic-conventions" "0.23.0"
     lodash.merge "^4.6.2"
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.4.3":


### PR DESCRIPTION
## Description

<!--- Include a summary of the changes, which issue is fixed and, relevant motivation and context -->
With the latest bump of @fwl/tracing to v0.10.3, our integration tests didn't passed anymore, due to the fact that the env var corresponding to tracing config was undefined during the tests. To fix it, I added the corresponding env var to CircleCI env vars, with just what was needed for the integration tests to pass (a service name). 

## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [ ] **Chore** (non-breaking change which refactors / improves the existing code base).
- [x] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Checklist

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
