### PR TITLE
Fixing contrast color issue in accessibility audits

### DIFF
--- a/src/components/cookie-banner/cookie-banner.tsx
+++ b/src/components/cookie-banner/cookie-banner.tsx
@@ -188,7 +188,7 @@ const FlexContainer = styled.div`
 
 const ServiceDesc = styled.p`
   font-size: ${({ theme }) => theme.fontSizes.xs};
-  color: ${({ theme }) => theme.colors.lightGrey};
+  color: ${({ theme }) => theme.colors.breadcrumbs};
   width: 85%;
   margin-top: 0.2rem;
 

--- a/src/components/input/input-switch.tsx
+++ b/src/components/input/input-switch.tsx
@@ -45,7 +45,7 @@ const Label = styled.label`
       height: 1.4rem;
       width: 1.4rem;
       position: absolute;
-      background-color: ${({ theme }) => theme.colors.lightGrey};
+      background-color: ${({ theme }) => theme.colors.breadcrumbs};
       border-radius: ${({ theme }) => theme.radii[3]};
       top: 0.2rem;
       left: 0.2rem;

--- a/src/components/pages/address-overview/address-overview.tsx
+++ b/src/components/pages/address-overview/address-overview.tsx
@@ -232,7 +232,7 @@ const Flex = styled.div`
 `;
 
 const CategoryName = styled.p`
-  color: ${({ theme }) => theme.colors.lightGrey};
+  color: ${({ theme }) => theme.colors.breadcrumbs};
   font-size: ${({ theme }) => theme.fontSizes.s};
   font-weight: ${({ theme }) => theme.fontWeights.medium};
   letter-spacing: 0.2rem;

--- a/src/components/pages/profile-overview/profile-overview.tsx
+++ b/src/components/pages/profile-overview/profile-overview.tsx
@@ -252,14 +252,14 @@ const UserPicture = styled.img`
 `;
 
 const PictureCategoryName = styled.p`
-  color: ${({ theme }) => theme.colors.lightGrey};
+  color: ${({ theme }) => theme.colors.breadcrumbs};
   font-size: ${({ theme }) => theme.fontSizes.s};
   font-weight: ${({ theme }) => theme.fontWeights.medium};
   letter-spacing: 0.2rem;
 `;
 
 const CategoryName = styled.p`
-  color: ${({ theme }) => theme.colors.lightGrey};
+  color: ${({ theme }) => theme.colors.breadcrumbs};
   font-size: ${({ theme }) => theme.fontSizes.s};
   font-weight: ${({ theme }) => theme.fontWeights.medium};
   letter-spacing: 0.2rem;


### PR DESCRIPTION
## Description

<!--- Include a summary of the changes, which issue is fixed and, relevant motivation and context -->
To improve our accessibility audits, I fixed a contrast colours issue that Lighthouse audits pointed up regarding some text on Profile Overview, or more recently on the new cookie banner. For that, I replaced the usage of `lightGrey` color variable for text content by `breadcrumbs` color variable. 

## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] **Chore** (non-breaking change which refactors / improves the existing code base).
- [ ] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Screenshots

<!--- if appropriate, otherwise the section can be removed -->
<img width="648" alt="image" src="https://user-images.githubusercontent.com/50053259/128543332-039197bf-51cf-4a3a-a78c-90a5ec7f0d64.png">



## Checklist

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
