### PR TITLE
Improving comment LH audits results to PRs script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,7 @@ jobs:
 
             if [ $(echo $pr_response | jq length) -eq 0 ]; then
               echo "No PR found to update"
+              exit 0
             else
               pr_comment_url=$(echo $pr_response | jq -r ".[]._links.comments.href")
             fi


### PR DESCRIPTION
## Description

<!--- Include a summary of the changes, which issue is fixed and, relevant motivation and context -->
Before this PR, the script used to send the LH audits results as a comment in the related PR didn't handle the fact that when the workflows are running against staging/main, there is no related PR and still try to post the comment but with no url. So the script ended in a fail state, which could be a bit confusing when looking at the overview of the workflows on CircleCI. To avoid this, I added a `exit 0` command in the condition case where we didn't find any PR related to current run. I tested it in review app env, seems to work (cf screenshot). Needs to be merge on main to be 100% sure. 

## Type of change

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [ ] **Chore** (non-breaking change which refactors / improves the existing code base).
- [x] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Screenshots

<img width="1419" alt="image" src="https://user-images.githubusercontent.com/50053259/129870449-2737c7e7-18a4-417f-aeb7-4ed81c17ccef.png">


## Checklist

<!--- To tick the checkbox, put an `x` inside the `[ ]` -->

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
