### PR TITLE
Miigrate layout css

### DIFF
--- a/src/components/page-layout.tsx
+++ b/src/components/page-layout.tsx
@@ -12,7 +12,7 @@ const Layout: React.FC<{
   title?: string;
 }> = ({ children, title, breadcrumbs }) => {
   return (
-    <Main>
+    <main className="w-full h-auto lg:h-screen max-w-screen-lg mx-auto">
       <MobileDisplayOnly>
         <Header viewport="mobile" />
         <MobileNavigationBar />
@@ -33,20 +33,9 @@ const Layout: React.FC<{
           <div className="container mb-40 lg:mb-0">{children}</div>
         </ChildrenContainer>
       </Flex>
-    </Main>
+    </main>
   );
 };
-
-const Main = styled.main`
-  width: 100%;
-  height: 100vh;
-  max-width: 102.4rem;
-  margin: 0 auto;
-
-  @media ${deviceBreakpoints.m} {
-    height: auto;
-  }
-`;
 
 const Flex = styled.div`
   display: flex;
@@ -97,4 +86,4 @@ const MainTitle = styled.h1<{ needSpacing?: boolean }>`
     needSpacing && `margin-bottom: ${theme.spaces.s}`}
 `;
 
-export { Layout, Main };
+export { Layout };

--- a/src/components/page-layout.tsx
+++ b/src/components/page-layout.tsx
@@ -1,11 +1,9 @@
 import React from "react";
-import styled from "styled-components";
 
 import { Header } from "./header";
 import { DesktopNavigationBar } from "./navigation-bars/desktop-navigation-bar";
 import { MobileNavigationBar } from "./navigation-bars/mobile-navigation-bar";
 import { NavigationBreadcrumbs } from "./navigation-breadcrumbs";
-import { deviceBreakpoints } from "@src/design-system/theme";
 
 const Layout: React.FC<{
   breadcrumbs: string | false;
@@ -13,77 +11,34 @@ const Layout: React.FC<{
 }> = ({ children, title, breadcrumbs }) => {
   return (
     <main className="w-full h-auto lg:h-screen max-w-screen-lg mx-auto">
-      <MobileDisplayOnly>
+      <div className="block lg:hidden">
         <Header viewport="mobile" />
         <MobileNavigationBar />
-      </MobileDisplayOnly>
-      <Flex>
-        <DesktopNavigationBarWrapper>
+      </div>
+      <div className="flex">
+        <div className="hidden lg:block w-2/6 font-semibold">
           <DesktopNavigationBar />
-        </DesktopNavigationBarWrapper>
-        <ChildrenContainer titleText={title} breadcrumbs={breadcrumbs}>
+        </div>
+        <div
+          className={`${
+            !title && !breadcrumbs ? "flex items-center" : ""
+          } w-11/12 lg:w-3/5 mx-auto`}
+        >
           {title ? (
-            <MainTitle
-              needSpacing={breadcrumbs || breadcrumbs === "" ? false : true}
+            <h1
+              className={`${
+                !breadcrumbs ? "mb-10 lg:mb-16" : ""
+              } mt-2 pt:4 lg:pt-10 pb-4`}
             >
               {title}
-            </MainTitle>
+            </h1>
           ) : null}
           <NavigationBreadcrumbs breadcrumbs={breadcrumbs} />
           <div className="container mb-40 lg:mb-0">{children}</div>
-        </ChildrenContainer>
-      </Flex>
+        </div>
+      </div>
     </main>
   );
 };
-
-const Flex = styled.div`
-  display: flex;
-`;
-
-const DesktopNavigationBarWrapper = styled.div`
-  min-width: 24rem;
-  width: 30%;
-  font-weight: ${({ theme }) => theme.fontWeights.semibold};
-
-  @media ${deviceBreakpoints.m} {
-    display: none;
-  }
-`;
-
-const ChildrenContainer = styled.div<{
-  breadcrumbs: string | false;
-  titleText?: string;
-}>`
-  width: 60%;
-  margin: 0 auto;
-
-  ${({ titleText, breadcrumbs }) =>
-    !titleText &&
-    !breadcrumbs &&
-    `
-      display: flex;
-      align-items: center;
-  `};
-
-  @media ${deviceBreakpoints.m} {
-    width: 90%;
-  }
-`;
-
-const MobileDisplayOnly = styled.div`
-  display: none;
-
-  @media ${deviceBreakpoints.m} {
-    display: block;
-  }
-`;
-
-const MainTitle = styled.h1<{ needSpacing?: boolean }>`
-  padding: 2.4rem 0 ${({ theme }) => theme.spaces.xxs};
-  margin-top: 0.5rem;
-  ${({ theme, needSpacing }) =>
-    needSpacing && `margin-bottom: ${theme.spaces.s}`}
-`;
 
 export { Layout };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,7 +11,6 @@ import { getServerSidePropsWithMiddlewares } from "@fwl/web/dist/next";
 import { GetServerSideProps } from "next";
 import React from "react";
 
-import { Main } from "@src/components/page-layout";
 import { Home } from "@src/components/pages/home";
 import { CONFIG_VARIABLES } from "@src/configs/config-variables";
 import { logger } from "@src/configs/logger";
@@ -24,9 +23,9 @@ type HomePageProps = { authorizeURL: string; providerName: string };
 
 const HomePage: React.FC<HomePageProps> = ({ authorizeURL, providerName }) => {
   return (
-    <Main>
+    <main className="w-full h-auto lg:h-screen max-w-screen-lg mx-auto">
       <Home authorizeURL={authorizeURL} providerName={providerName} />
-    </Main>
+    </main>
   );
 };
 


### PR DESCRIPTION
## Description

This PR aims at migrating the layout from `styled-components` to `tailwindcss`.

I had to changes some initial css values to keep the native classes (e.g. `width: 30%;` => `2/6` which is `33.33%`), and I improved the overall mobile spacing.

## Type of change

- [x] **Chore** (non-breaking change which refactors / improves the existing code base).
- [ ] **Bug fix** (non-breaking change which fixes an issue).
- [ ] **New feature** (non-breaking change which adds functionality).
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected).

## Checklist

- [x] My code follows the style [**contributing guidelines**][contributing_file] of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

[contributing_file]: https://github.com/fewlinesco/connect-account/blob/master/README.adoc
